### PR TITLE
feat: 투두 CRUD, 완료/취소 구현

### DIFF
--- a/src/main/java/com/grepp/codemap/todo/controller/TodoController.java
+++ b/src/main/java/com/grepp/codemap/todo/controller/TodoController.java
@@ -1,0 +1,121 @@
+package com.grepp.codemap.todo.controller;
+
+import com.grepp.codemap.todo.dto.TodoCreateRequest;
+import com.grepp.codemap.todo.dto.TodoUpdateRequest;
+import com.grepp.codemap.todo.dto.TodoResponse;
+import com.grepp.codemap.todo.domain.Todo;
+import com.grepp.codemap.todo.service.TodoService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/todos")
+public class TodoController {
+
+    private final TodoService todoService;
+
+    /** ✅ 1. 캘린더 진입 화면 */
+    @GetMapping("/calender")
+    public String showCalendarPage() {
+        return "todo/calender";
+    }
+
+    /** ✅ 2. 선택 날짜 투두 조회 */
+    @GetMapping
+    public String getTodoList(@RequestParam("date") String date,
+        @SessionAttribute("userId") Long userId,
+        Model model) {
+        LocalDate localDate = LocalDate.parse(date);
+        LocalDateTime startOfDay = localDate.atStartOfDay();
+        LocalDateTime endOfDay = localDate.atTime(LocalTime.MAX);
+
+        List<TodoResponse> todos = todoService.getTodosByDate(userId, startOfDay, endOfDay);
+        model.addAttribute("todos", todos);
+        model.addAttribute("selectedDate", date);
+        return "todo/todo-list";
+    }
+
+    /** ✅ 3. 추가 폼 (모달에서 불러옴) */
+    @GetMapping("/new")
+    public String showCreateForm(@RequestParam("date") String date, Model model) {
+        model.addAttribute("selectedDate", date);
+        return "todo/todo-form";
+    }
+
+    /** ✅ 4. 투두 생성 */
+    @PostMapping
+    public String createTodo(@SessionAttribute("userId") Long userId,
+        @ModelAttribute @Valid TodoCreateRequest request) {
+        Todo created = todoService.createTodo(
+            userId,
+            request.title(),
+            request.description(),
+            request.startTime(),
+            request.completedAt()
+        );
+        return "redirect:/todos?date=" + created.getCompletedAt().toLocalDate();
+    }
+
+    /** ✅ 5. 수정 폼 (모달에서 불러옴) */
+    @GetMapping("/{id}/edit")
+    public String showEditForm(@PathVariable Long id,
+        @SessionAttribute("userId") Long userId,
+        @RequestParam("date") String date,
+        Model model) {
+        Todo todo = todoService.findByIdAndUser(id, userId);
+        model.addAttribute("todo", todo);
+        model.addAttribute("selectedDate", date);
+        return "todo/todo-form";
+    }
+
+    /** ✅ 6. 투두 수정 */
+    @PatchMapping("/{id}")
+    public String updateTodo(@PathVariable Long id,
+        @SessionAttribute("userId") Long userId,
+        @ModelAttribute @Valid TodoUpdateRequest request) {
+        Todo updated = todoService.updateTodo(
+            id,
+            userId,
+            request.title(),
+            request.description(),
+            request.completedAt()
+        );
+        return "redirect:/todos?date=" + updated.getCompletedAt().toLocalDate();
+    }
+
+    /** ✅ 7. 투두 삭제 */
+    @DeleteMapping("/{id}")
+    public String deleteTodo(@PathVariable Long id,
+        @SessionAttribute("userId") Long userId,
+        @RequestParam("date") String date) {
+        todoService.deleteTodo(id, userId);
+        return "redirect:/todos?date=" + date;
+    }
+
+    /** ✅ 8. 완료 상태 토글 (체크박스 클릭) */
+    @PatchMapping("/{id}/complete")
+    public String toggleComplete(@PathVariable Long id,
+        @SessionAttribute("userId") Long userId,
+        @RequestParam("date") String date) {
+        todoService.toggleComplete(id, userId);
+        return "redirect:/todos?date=" + date;
+    }
+
+    /** ✅ 9. 완료 취소 */
+    @PatchMapping("/{id}/cancel")
+    public String cancelComplete(@PathVariable Long id,
+        @SessionAttribute("userId") Long userId,
+        @RequestParam("date") String date) {
+        todoService.toggleComplete(id, userId); // 같은 toggle 메서드 사용
+        return "redirect:/todos?date=" + date;
+    }
+}

--- a/src/main/java/com/grepp/codemap/todo/domain/Todo.java
+++ b/src/main/java/com/grepp/codemap/todo/domain/Todo.java
@@ -64,4 +64,20 @@ public class Todo {
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public void setCompletedAt(LocalDateTime completedAt) {
+        this.completedAt = completedAt;
+    }
+
+    public void setIsCompleted(boolean b) {
+        this.isCompleted = b;
+    }
 }

--- a/src/main/java/com/grepp/codemap/todo/dto/TodoCreateRequest.java
+++ b/src/main/java/com/grepp/codemap/todo/dto/TodoCreateRequest.java
@@ -1,0 +1,23 @@
+package com.grepp.codemap.todo.dto;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+/**
+ * 투두 생성 요청 DTO
+ */
+public record TodoCreateRequest(
+    @NotBlank(message = "제목을 입력해주세요.")
+    String title,
+
+    String description,
+
+    @NotNull(message = "시작 시간을 입력해주세요.")
+    LocalDateTime startTime,
+
+    @NotNull(message = "완료 시간을 입력해주세요.")
+    @FutureOrPresent(message = "완료 시간은 현재 시간 이후여야 합니다.")
+    LocalDateTime completedAt
+) {}

--- a/src/main/java/com/grepp/codemap/todo/dto/TodoResponse.java
+++ b/src/main/java/com/grepp/codemap/todo/dto/TodoResponse.java
@@ -1,0 +1,31 @@
+package com.grepp.codemap.todo.dto;
+
+import com.grepp.codemap.todo.domain.Todo;
+import java.time.LocalDateTime;
+
+/**
+ * 투두 조회 응답 DTO
+ */
+public record TodoResponse(
+    Long id,
+    String title,
+    String description,
+    Boolean isCompleted,
+    LocalDateTime startTime,
+    LocalDateTime completedAt,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+    public static TodoResponse of(Todo todo) {
+        return new TodoResponse(
+            todo.getId(),
+            todo.getTitle(),
+            todo.getDescription(),
+            todo.getIsCompleted(),
+            todo.getStartTime(),
+            todo.getCompletedAt(),
+            todo.getCreatedAt(),
+            todo.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/grepp/codemap/todo/dto/TodoUpdateRequest.java
+++ b/src/main/java/com/grepp/codemap/todo/dto/TodoUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.grepp.codemap.todo.dto;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+/**
+ * 투두 수정 요청 DTO
+ */
+public record TodoUpdateRequest(
+    @NotBlank(message = "제목을 입력해주세요.")
+    String title,
+
+    String description,
+
+    @NotNull(message = "완료 시간을 입력해주세요.")
+    @FutureOrPresent(message = "완료 시간은 현재 시간 이후여야 합니다.")
+    LocalDateTime completedAt
+) {}

--- a/src/main/java/com/grepp/codemap/todo/repository/TodoRepository.java
+++ b/src/main/java/com/grepp/codemap/todo/repository/TodoRepository.java
@@ -1,0 +1,39 @@
+package com.grepp.codemap.todo.repository;
+
+import com.grepp.codemap.todo.domain.Todo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Todo 엔티티에 대한 CRUD 및 커스텀 조회 메서드를 제공하는 리포지토리
+ */
+@Repository
+public interface TodoRepository extends JpaRepository<Todo, Long> {
+
+    /**
+     * 특정 사용자가 지정한 기간(start~end) 동안 시작 예정인 Todo 리스트 조회
+     *
+     * @param userId 조회 대상 사용자 ID
+     * @param start  조회 기간 시작 시각 (inclusive)
+     * @param end    조회 기간 종료 시각 (inclusive)
+     * @return 기간 내 해당 사용자의 Todo 리스트
+     */
+    List<Todo> findAllByUser_IdAndStartTimeBetween(
+        Long userId,
+        LocalDateTime start,
+        LocalDateTime end
+    );
+
+    /**
+     * 단건 조회 시, 사용자 권한 검증을 위해 ID와 user_id를 함께 조회
+     *
+     * @param id     조회할 Todo ID
+     * @param userId 조회 대상 사용자 ID
+     * @return Todo (존재하지 않으면 null 반환)
+     */
+
+    Todo findByIdAndUser_Id(Long id, Long userId);
+}

--- a/src/main/java/com/grepp/codemap/todo/service/TodoService.java
+++ b/src/main/java/com/grepp/codemap/todo/service/TodoService.java
@@ -1,0 +1,105 @@
+package com.grepp.codemap.todo.service;
+
+import com.grepp.codemap.todo.domain.Todo;
+import com.grepp.codemap.todo.dto.TodoResponse;
+import com.grepp.codemap.todo.repository.TodoRepository;
+import com.grepp.codemap.user.domain.User;
+import com.grepp.codemap.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Todo 관련 비즈니스 로직을 처리하는 서비스 클래스
+ */
+@Service
+@Transactional
+public class TodoService {
+
+    private final TodoRepository todoRepository;
+    private final UserRepository userRepository;
+
+    // 생성자를 통한 의존성 주입
+    public TodoService(TodoRepository todoRepository, UserRepository userRepository) {
+        this.todoRepository = todoRepository;
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * 특정 기간 동안 사용자의 Todo 목록을 조회한다.
+     *
+     * @param userId 사용자 ID
+     * @param start  조회 시작 시각 (inclusive)
+     * @param end    조회 종료 시각 (inclusive)
+     * @return 기간 내 Todo 응답 DTO 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<TodoResponse> getTodosByDate(Long userId, LocalDateTime start, LocalDateTime end) {
+        List<Todo> todos = todoRepository.findAllByUser_IdAndStartTimeBetween(userId, start, end);
+        return todos.stream()
+            .map(TodoResponse::of)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public Todo getTodosForDate(Long userId, LocalDateTime start, LocalDateTime end) {
+        return (Todo) todoRepository.findAllByUser_IdAndStartTimeBetween(userId, start, end);
+    }
+
+    @Transactional(readOnly = true)
+    public Todo findByIdAndUser(Long id, Long userId) {
+        Todo todo = todoRepository.findByIdAndUser_Id(id, userId);
+        if (todo == null) {
+            throw new IllegalArgumentException("해당 Todo를 찾을 수 없습니다.");
+        }
+        return todo;
+    }
+
+    public Todo createTodo(Long userId,
+        String title,
+        String description,
+        LocalDateTime startTime,
+        LocalDateTime completedAt) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 사용자입니다."));
+
+        Todo todo = Todo.builder()
+            .user(user)
+            .title(title)
+            .description(description)
+            .startTime(startTime)
+            .completedAt(completedAt)
+            .isCompleted(false)
+            .isDeleted(false)
+            .build();
+
+        return todoRepository.save(todo);
+    }
+
+    public Todo updateTodo(Long id,
+        Long userId,
+        String title,
+        String description,
+        LocalDateTime completedAt) {
+        Todo todo = findByIdAndUser(id, userId);
+        todo.setTitle(title);
+        todo.setDescription(description);
+        todo.setCompletedAt(completedAt);
+        return todoRepository.save(todo);
+    }
+
+    public void deleteTodo(Long id, Long userId) {
+        Todo todo = findByIdAndUser(id, userId);
+        todoRepository.delete(todo);
+    }
+
+    public Todo toggleComplete(Long id, Long userId) {
+        Todo todo = findByIdAndUser(id, userId);
+        boolean current = todo.getIsCompleted();
+        todo.setIsCompleted(!current);
+        return todoRepository.save(todo);
+    }
+}


### PR DESCRIPTION

## 📌 과제 설명 

사용자 별 Todo 리스트를 등록하고 조회, 수정, 삭제할 수 있도록 하는 기능을 JPA 기반으로 구현했습니다.
프론트에서 날짜를 선택했을 때 해당 날짜에 맞는 Todo 데이터를 반환하고, 생성 및 완료 상태 토글도 가능합니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

**TodoController 생성 및 기능 구현**
- /todos 경로에 대해 RESTful CRUD 처리
- 날짜 범위 기반 조회 및 완료 상태 토글 API 구현

**TodoService 작성**
- 사용자 ID 기반의 권한 검증 로직 포함
- LocalDateTime 기반으로 기간 내 Todo 조회, 등록, 수정, 삭제 처리
- toggleComplete() 메서드를 통한 완료 여부 토글

**TodoRepository 작성**
- findAllByUser_IdAndStartTimeBetween() 등 사용자 기준 커스텀 쿼리 메서드 정의

**DTO 정의**
- TodoCreateRequest, TodoUpdateRequest, TodoResponse 구현
- TodoResponse.of() 메서드를 통해 Entity -> DTO 변환

**Todo 엔티티 도메인 작성**
- Setter 대신, 직접 변경 메서드(setTitle, setDescription, 등) 구현하여 명시적으로 상태 관리




## ✅ 피드백 반영사항  

**@Setter 사용 대신, 명시적인 변경 메서드를 통해 엔티티의 불변성과 명확한 변경 포인트 유지**

## ✅ PR 포인트 & 궁금한 점 
