### PR TITLE
add : 필수루틴 추가 , 타이ë머 ìfeat : ¤제 사용 시간 반영 ê¸

### DIFF
--- a/src/main/java/com/grepp/codemap/mypage/controller/MyPageViewController.java
+++ b/src/main/java/com/grepp/codemap/mypage/controller/MyPageViewController.java
@@ -40,6 +40,9 @@ public class MyPageViewController {
         RoutineCompletionDto completionDto = myPageService.getRoutineCompletionStats(user.getId());
         List<RoutineCategoryCompletionDto> categoryStats = myPageService.getRoutineCompletionStatsByCategory(user.getId());
 
+        Integer totalActualFocusTime = myPageService.getTotalActualFocusTime(user.getId());
+        Map<String, Integer> actualFocusTimeByCategory = myPageService.getActualFocusTimeByCategory(user.getId());
+
         Map<String, Integer> rawFocusMap = myPageService.getFocusTimePerDay(user.getId());
         Map<String, Integer> orderedFocusMap = new LinkedHashMap<>();
         for (String day : WEEKDAYS) {
@@ -54,6 +57,9 @@ public class MyPageViewController {
         model.addAttribute("categoryStats", categoryStats);
         model.addAttribute("focusTimes", orderedFocusMap);
         model.addAttribute("todayTodos", todayTodos);
+
+        model.addAttribute("totalActualFocusTime", totalActualFocusTime);
+        model.addAttribute("actualFocusTimeByCategory", actualFocusTimeByCategory);
 
         return "mypage/stats";
     }

--- a/src/main/java/com/grepp/codemap/mypage/dto/UserStatDto.java
+++ b/src/main/java/com/grepp/codemap/mypage/dto/UserStatDto.java
@@ -9,7 +9,9 @@ import lombok.Getter;
 public class UserStatDto {
 
     private Integer totalFocusMinutes;          // 총 순공 시간
+    private Integer totalActualFocusMinutes;  // 실제 순공 시간
     private String dailyCompletionRateJson; // 카테고리별 완료율(Json)
     private List<String> chartDates;
     private List<Integer> chartFocusMinutes;
+    private List<Integer> chartActualFocusMinutes; // 실제 시간 차트용
 }

--- a/src/main/java/com/grepp/codemap/mypage/service/MyPageService.java
+++ b/src/main/java/com/grepp/codemap/mypage/service/MyPageService.java
@@ -5,7 +5,10 @@ import com.grepp.codemap.mypage.dto.RoutineCompletionDto;
 import com.grepp.codemap.routine.repository.DailyRoutineRepository;
 import com.grepp.codemap.todo.domain.Todo;
 import com.grepp.codemap.todo.repository.TodoRepository;
+import com.grepp.codemap.user.domain.User;
+import com.grepp.codemap.user.repository.UserRepository;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.LinkedHashMap;
@@ -18,6 +21,7 @@ public class MyPageService {
 
     private final DailyRoutineRepository dailyRoutineRepository;
     private final TodoRepository todoRepository;
+    private final UserRepository userRepository;
 
     private static final Map<Integer, String> WEEKDAY_MAP = Map.of(
         2, "월", 3, "화", 4, "수", 5, "목", 6, "금", 7, "토", 1, "일"
@@ -41,7 +45,7 @@ public class MyPageService {
     }
 
     public Map<String, Integer> getFocusTimePerDay(Long userId) {
-        List<Object[]> result = dailyRoutineRepository.sumFocusTimeGroupedByWeekday(userId);
+        List<Object[]> result = dailyRoutineRepository.sumActualFocusTimeGroupedByWeekday(userId);
         Map<String, Integer> focusMap = new LinkedHashMap<>();
 
         // 요일 순서대로 초기화
@@ -52,12 +56,37 @@ public class MyPageService {
 
         for (Object[] row : result) {
             Integer weekdayNumber = ((Number) row[0]).intValue(); // 1~7
-            Integer focusTime = ((Number) row[1]).intValue();
+            Integer actualFocusTime = row[1] != null ? ((Number) row[1]).intValue() : 0;
             String weekday = WEEKDAY_MAP.get(weekdayNumber);
-            focusMap.put(weekday, focusTime);
+            if (weekday != null) {
+                focusMap.put(weekday, actualFocusTime);
+            }
         }
 
         return focusMap;
+    }
+    public Integer getTotalActualFocusTime(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        Integer total = dailyRoutineRepository.getTotalActualFocusTimeByUser(user);
+        return total != null ? total : 0;
+    }
+
+    public Map<String, Integer> getActualFocusTimeByCategory(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        List<Object[]> results = dailyRoutineRepository.getTotalActualFocusTimeByCategory(user);
+        Map<String, Integer> categoryMap = new HashMap<>();
+
+        for (Object[] row : results) {
+            String category = (String) row[0];
+            Integer actualTime = row[1] != null ? ((Number) row[1]).intValue() : 0;
+            categoryMap.put(category, actualTime);
+        }
+
+        return categoryMap;
     }
 
     public List<Todo> getTodayTodos(Long userId) {

--- a/src/main/java/com/grepp/codemap/routine/domain/InterviewReview.java
+++ b/src/main/java/com/grepp/codemap/routine/domain/InterviewReview.java
@@ -1,6 +1,5 @@
 package com.grepp.codemap.routine.domain;
 
-import com.grepp.codemap.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -20,39 +19,34 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "daily_routines")
+@Table(name = "interview_reviews")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class DailyRoutine {
+public class InterviewReview {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+    @JoinColumn(name = "routine_id")
+    private DailyRoutine routine;
 
-    private String category;
+    private String techCategory; // 기술 분야 (알고리즘, 자료구조, 데이터베이스 등)
 
-    private String title;
+    @Column(columnDefinition = "TEXT")
+    private String studyContent; // 오늘 공부한 내용
 
-    private String description;
+    @Column(columnDefinition = "TEXT")
+    private String learnedConcepts; // 학습한 개념들
 
-    @Column(name = "status")
-    private String status; // ACTIVE, COMPLETED, PASS
+    @Column(columnDefinition = "TEXT")
+    private String difficultParts; // 어려웠던 부분
 
-    private Integer focusTime;
-    private Integer actualFocusTime;
-
-    @Builder.Default
-    private Integer breakTime = 5;
-
-    private LocalDateTime startedAt;
-
-    private LocalDateTime completedAt;
+    @Column(columnDefinition = "TEXT")
+    private String nextStudyPlan; // 다음에 공부할 내용
 
     @Builder.Default
     private Boolean isDeleted = false;

--- a/src/main/java/com/grepp/codemap/routine/dto/DailyRoutineDto.java
+++ b/src/main/java/com/grepp/codemap/routine/dto/DailyRoutineDto.java
@@ -20,6 +20,7 @@ public class DailyRoutineDto {
     private String description;
     private String status;
     private Integer focusTime;
+    private Integer actualFocusTime;
     private Integer breakTime;
     private LocalDateTime startedAt;
     private LocalDateTime completedAt;
@@ -36,6 +37,7 @@ public class DailyRoutineDto {
             .description(entity.getDescription())
             .status(entity.getStatus())
             .focusTime(entity.getFocusTime())
+            .actualFocusTime(entity.getActualFocusTime())
             .breakTime(entity.getBreakTime())
             .startedAt(entity.getStartedAt())
             .completedAt(entity.getCompletedAt())

--- a/src/main/java/com/grepp/codemap/routine/dto/InterviewReviewDto.java
+++ b/src/main/java/com/grepp/codemap/routine/dto/InterviewReviewDto.java
@@ -1,0 +1,40 @@
+package com.grepp.codemap.routine.dto;
+
+import com.grepp.codemap.routine.domain.InterviewReview;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InterviewReviewDto {
+    private Long id;
+    private Long routineId;
+    private String techCategory; // 기술 분야
+    private String studyContent; // 오늘 공부한 내용
+    private String learnedConcepts; // 학습한 개념들
+    private String difficultParts; // 어려웠던 부분
+    private String nextStudyPlan; // 다음에 공부할 내용
+    private Boolean isDeleted;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static InterviewReviewDto fromEntity(InterviewReview entity) {
+        return InterviewReviewDto.builder()
+            .id(entity.getId())
+            .routineId(entity.getRoutine().getId())
+            .techCategory(entity.getTechCategory())
+            .studyContent(entity.getStudyContent())
+            .difficultParts(entity.getDifficultParts())
+            .nextStudyPlan(entity.getNextStudyPlan())
+            .isDeleted(entity.getIsDeleted())
+            .createdAt(entity.getCreatedAt())
+            .updatedAt(entity.getUpdatedAt())
+            .build();
+    }
+}

--- a/src/main/java/com/grepp/codemap/routine/repository/DailyRoutineRepository.java
+++ b/src/main/java/com/grepp/codemap/routine/repository/DailyRoutineRepository.java
@@ -58,4 +58,22 @@ public interface DailyRoutineRepository extends JpaRepository<DailyRoutine, Long
     List<Object[]> sumFocusTimeGroupedByWeekday(@Param("userId") Long userId);
 
 
+
+    // 실제 집중 시간 기반 총 시간 조회
+    @Query("SELECT SUM(dr.actualFocusTime) FROM DailyRoutine dr WHERE dr.user = :user AND dr.status = 'COMPLETED' AND dr.isDeleted = false AND dr.actualFocusTime IS NOT NULL")
+    Integer getTotalActualFocusTimeByUser(@Param("user") User user);
+
+    // 실제 집중 시간 기반 카테고리별 시간 조회
+    @Query("SELECT dr.category, SUM(dr.actualFocusTime) FROM DailyRoutine dr WHERE dr.user = :user AND dr.status = 'COMPLETED' AND dr.isDeleted = false AND dr.actualFocusTime IS NOT NULL GROUP BY dr.category")
+    List<Object[]> getTotalActualFocusTimeByCategory(@Param("user") User user);
+
+    // 실제 집중 시간 기반 요일별 시간 조회
+    @Query(value = """
+        SELECT DAYOFWEEK(r.created_at) AS weekday, SUM(r.actual_focus_time)
+        FROM daily_routines r
+        WHERE r.user_id = :userId AND r.status = 'COMPLETED' AND r.is_deleted = false AND r.actual_focus_time IS NOT NULL
+        GROUP BY DAYOFWEEK(r.created_at)
+    """, nativeQuery = true)
+    List<Object[]> sumActualFocusTimeGroupedByWeekday(@Param("userId") Long userId);
+
 }

--- a/src/main/java/com/grepp/codemap/routine/repository/InterviewReviewRepository.java
+++ b/src/main/java/com/grepp/codemap/routine/repository/InterviewReviewRepository.java
@@ -1,0 +1,22 @@
+package com.grepp.codemap.routine.repository;
+
+import com.grepp.codemap.routine.domain.InterviewReview;
+import com.grepp.codemap.routine.domain.DailyRoutine;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface InterviewReviewRepository extends JpaRepository<InterviewReview, Long> {
+
+    List<InterviewReview> findByRoutineAndIsDeletedFalse(DailyRoutine routine);
+
+    @Query("SELECT i FROM InterviewReview i WHERE i.routine.id = :routineId AND i.isDeleted = false")
+    List<InterviewReview> findByRoutineIdAndIsDeletedFalse(@Param("routineId") Long routineId);
+
+    @Modifying
+    @Query("DELETE FROM InterviewReview i WHERE i.routine.id IN (SELECT r.id FROM DailyRoutine r WHERE r.user.id = :userId)")
+    void deleteByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/grepp/codemap/user/controller/UserController.java
+++ b/src/main/java/com/grepp/codemap/user/controller/UserController.java
@@ -80,8 +80,8 @@ public class UserController {
             List<DailyRoutineDto> passedRoutines = routinesByStatus.get("passed");
 
             // 오늘의 총 집중시간 계산 (완료된 루틴들의 집중시간 합)
-            int totalFocusMinutes = completedRoutines.stream()
-                .mapToInt(routine -> routine.getFocusTime() != null ? routine.getFocusTime() : 0)
+            int totalActualFocusMinutes = completedRoutines.stream()
+                .mapToInt(routine -> routine.getActualFocusTime() != null ? routine.getActualFocusTime() : 0)
                 .sum();
 
             // 전체 루틴 수와 완료된 루틴 수
@@ -96,7 +96,7 @@ public class UserController {
             model.addAttribute("completedRoutines", completedRoutines);
             model.addAttribute("passedRoutines", passedRoutines);
             model.addAttribute("todayTodos", todayTodos);
-            model.addAttribute("totalFocusMinutes", totalFocusMinutes);
+            model.addAttribute("totalActualFocusMinutes", totalActualFocusMinutes);
             model.addAttribute("totalRoutines", totalRoutines);
             model.addAttribute("completedRoutineCount", completedRoutineCount);
             model.addAttribute("completionRate", Math.round(completionRate));

--- a/src/main/resources/templates/mypage/stats.html
+++ b/src/main/resources/templates/mypage/stats.html
@@ -113,7 +113,7 @@
         <div class="summary-box">
           <p>✔ 완료된 루틴: <span th:text="${completion.completedCount}">0</span>개 /
             남은 루틴: <span th:text="${completion.totalCount - completion.completedCount}">0</span>개</p>
-          <p>✔ 오늘의 순공 시간: <span th:text="${userStat.totalFocusMinutes}">0</span>분</p>
+          <p>✔ 오늘의 순공 시간: <span th:text="${totalActualFocusTime}">0</span>분</p>
         </div>
       </div>
 

--- a/src/main/resources/templates/routine/coding-review.html
+++ b/src/main/resources/templates/routine/coding-review.html
@@ -77,8 +77,9 @@
 
     .routine-info h3 {
       color: #1b2c50;
-      margin-bottom: 5px;
-    }
+      font-size: 20px;
+      font-weight: 600;
+      margin: 0 0 15px 0;    }
 
     .routine-info p {
       color: #666;
@@ -206,11 +207,12 @@
 
     <div class="routine-info">
       <h3 th:text="${routine.title}">루틴 제목</h3>
-      <p><strong>카테고리:</strong> <span th:text="${routine.category}">카테고리</span></p>
       <p><strong>설명:</strong> <span th:text="${routine.description}">설명</span></p>
       <p><strong>집중 시간:</strong> <span th:text="${routine.focusTime}">60</span>분</p>
     </div>
 
+
+    <!-- 작성 모드 -->
     <form th:if="${!isViewMode}" th:action="@{'/routines/' + ${routine.id} + '/coding-review'}" method="post" id="reviewForm">
       <input type="hidden" name="sessionId" th:value="${sessionId}" />
 
@@ -220,20 +222,6 @@
             <h4>문제 1</h4>
             <button type="button" class="remove-problem" onclick="removeProblem(this)" style="display: none;">삭제</button>
           </div>
-
-          <label>문제 종류</label>
-          <select name="problemTypes" required>
-            <option value="">선택하세요</option>
-            <option value="자료구조">자료구조</option>
-            <option value="BFS/DFS">BFS/DFS</option>
-            <option value="구현">구현</option>
-            <option value="다익스트라">다익스트라</option>
-            <option value="트리">트리</option>
-            <option value="다이나믹 프로그래밍">다이나믹 프로그래밍</option>
-            <option value="탐색">탐색</option>
-            <option value="그리디">그리디</option>
-            <option value="기타">기타</option>
-          </select>
 
           <label>문제 제목</label>
           <input type="text" name="problemTitles" placeholder="문제 제목을 입력하세요" required />
@@ -264,9 +252,6 @@
           <h4 th:text="'문제 ' + ${iterStat.count}">문제 1</h4>
         </div>
 
-        <label>문제 종류</label>
-        <input type="text" th:value="${review.problemType}" readonly />
-
         <label>문제 제목</label>
         <input type="text" th:value="${review.problemTitle}" readonly />
 
@@ -293,7 +278,6 @@
   function addProblem() {
     problemCount++;
     const container = document.getElementById('problemsContainer');
-
     const newProblem = document.createElement('div');
     newProblem.className = 'problem-section';
 
@@ -303,19 +287,7 @@
         <button type="button" class="remove-problem" onclick="removeProblem(this)">삭제</button>
       </div>
 
-      <label>문제 종류</label>
-      <select name="problemTypes" required>
-        <option value="">선택하세요</option>
-        <option value="자료구조">자료구조</option>
-        <option value="BFS/DFS">BFS/DFS</option>
-        <option value="구현">구현</option>
-        <option value="다익스트라">다익스트라</option>
-        <option value="트리">트리</option>
-        <option value="다이나믹 프로그래밍">다이나믹 프로그래밍</option>
-        <option value="탐색">탐색</option>
-        <option value="그리디">그리디</option>
-        <option value="기타">기타</option>
-      </select>
+
 
       <label>문제 제목</label>
       <input type="text" name="problemTitles" placeholder="문제 제목을 입력하세요" required />

--- a/src/main/resources/templates/routine/interview-review.html
+++ b/src/main/resources/templates/routine/interview-review.html
@@ -1,0 +1,486 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="_csrf" th:content="${_csrf?.token}" />
+  <meta name="_csrf_header" th:content="${_csrf?.headerName}" />
+  <title>면접준비 회고</title>
+
+  <!-- 공통 스타일 -->
+  <link rel="stylesheet" th:href="@{/css/header/global.css}" />
+  <link rel="stylesheet" th:href="@{/css/header/style.css}" />
+  <link rel="stylesheet" th:href="@{/css/header/styleguide.css}" />
+  <link rel="stylesheet" th:href="@{/css/sidenav/user/globals.css}" />
+  <link rel="stylesheet" th:href="@{/css/sidenav/user/style.css}" />
+  <link rel="stylesheet" th:href="@{/css/sidenav/user/styleguide.css}" />
+
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      background-color: #f8f9fa;
+      font-family: "Pretendard", sans-serif;
+    }
+
+    header {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 1000;
+    }
+
+    aside {
+      position: fixed;
+      top: 116px;
+      left: 0;
+      width: 250px;
+      height: calc(100% - 116px);
+      z-index: 900;
+    }
+
+    main {
+      margin-left: 250px;
+      margin-top: -40vw;
+      padding: 30px;
+      min-height: calc(100vh - 116px);
+    }
+
+    .review-container {
+      max-width: 900px;
+      margin: 0 auto;
+      background-color: #d8e3ff;
+      border-radius: 16px;
+      padding: 30px;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+    }
+
+    .review-header {
+      text-align: center;
+      margin-bottom: 30px;
+    }
+
+    .review-header h2 {
+      color: #1b2c50;
+      font-size: 28px;
+      font-weight: 700;
+      margin: 0;
+    }
+
+    .routine-info {
+      background-color: #f0f6ff;
+      border: 2px solid #4e6df2;
+      border-radius: 12px;
+      padding: 20px;
+      margin-bottom: 30px;
+    }
+
+    .routine-info h3 {
+      color: #1b2c50;
+      font-size: 20px;
+      font-weight: 600;
+      margin: 0 0 15px 0;
+    }
+
+    .routine-info p {
+      margin: 8px 0;
+      color: #666;
+      font-size: 14px;
+    }
+
+    .routine-info strong {
+      color: #1b2c50;
+      font-weight: 600;
+    }
+
+    .study-section {
+      background-color: white;
+      border: 2px solid #e0e7ff;
+      border-radius: 12px;
+      padding: 25px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    }
+
+    .study-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 20px;
+      padding-bottom: 15px;
+      border-bottom: 2px solid #f0f6ff;
+    }
+
+    .study-header h4 {
+      color: #1b2c50;
+      font-size: 18px;
+      font-weight: 600;
+      margin: 0;
+    }
+
+    .remove-study {
+      background-color: #dc3545;
+      color: white;
+      border: none;
+      padding: 6px 12px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 12px;
+      font-weight: 500;
+    }
+
+    .remove-study:hover {
+      background-color: #c82333;
+    }
+
+    label {
+      display: block;
+      margin-bottom: 6px;
+      margin-top: 15px;
+      color: #1b2c50;
+      font-weight: 600;
+      font-size: 14px;
+    }
+
+    label:first-of-type {
+      margin-top: 0;
+    }
+
+    select, textarea {
+      width: 100%;
+      padding: 12px;
+      border: 2px solid #e0e7ff;
+      border-radius: 8px;
+      font-size: 14px;
+      font-family: "Pretendard", sans-serif;
+      transition: border-color 0.3s ease;
+      resize: vertical;
+      box-sizing: border-box;
+    }
+
+    select:focus, textarea:focus {
+      outline: none;
+      border-color: #4e6df2;
+      box-shadow: 0 0 0 3px rgba(78, 109, 242, 0.1);
+    }
+
+    textarea {
+      min-height: 80px;
+    }
+
+    .button-group {
+      display: flex;
+      justify-content: center;
+      gap: 12px;
+      margin-top: 30px;
+      flex-wrap: wrap;
+    }
+
+    .button-group button {
+      padding: 12px 24px;
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 600;
+      transition: all 0.3s ease;
+      min-width: 120px;
+    }
+
+    .button-group button[type="button"]:first-child {
+      background-color: #28a745;
+      color: white;
+    }
+
+    .button-group button[type="button"]:first-child:hover {
+      background-color: #218838;
+      transform: translateY(-1px);
+    }
+
+    .button-group button[type="submit"] {
+      background-color: #4e6df2;
+      color: white;
+    }
+
+    .button-group button[type="submit"]:hover {
+      background-color: #3b6fe0;
+      transform: translateY(-1px);
+    }
+
+    .button-group button[onclick*="routines"] {
+      background-color: #6c757d;
+      color: white;
+    }
+
+    .button-group button[onclick*="routines"]:hover {
+      background-color: #5a6268;
+      transform: translateY(-1px);
+    }
+
+    /* 조회 모드 스타일 */
+    .view-content .study-section {
+      background-color: #f8f9ff;
+      border-color: #c7d2fe;
+    }
+
+    .view-field {
+      margin-bottom: 20px;
+    }
+
+    .view-field label {
+      margin-bottom: 8px;
+      color: #1b2c50;
+      font-weight: 600;
+    }
+
+    .field-content {
+      background-color: white;
+      padding: 12px;
+      border: 2px solid #e0e7ff;
+      border-radius: 8px;
+      color: #333;
+      line-height: 1.5;
+      min-height: 20px;
+      white-space: pre-wrap;
+    }
+
+    /* 반응형 디자인 */
+    @media (max-width: 768px) {
+      main {
+        margin-left: 0;
+        padding: 20px;
+      }
+
+      .review-container {
+        padding: 20px;
+      }
+
+      .study-section {
+        padding: 20px;
+      }
+
+      .button-group {
+        flex-direction: column;
+        align-items: center;
+      }
+
+      .button-group button {
+        width: 100%;
+        max-width: 300px;
+      }
+    }
+
+    /* 폼 유효성 검사 오류 스타일 */
+    .error {
+      border-color: #dc3545 !important;
+      box-shadow: 0 0 0 3px rgba(220, 53, 69, 0.1) !important;
+    }
+
+    /* 로딩 상태 */
+    .loading {
+      opacity: 0.6;
+      pointer-events: none;
+    }
+
+    /* 성공 메시지 */
+    .success-message {
+      background-color: #d4edda;
+      color: #155724;
+      padding: 12px;
+      border-radius: 8px;
+      margin-bottom: 20px;
+      border: 1px solid #c3e6cb;
+    }
+  </style>
+</head>
+<body>
+<!--알림 -->
+<th:block th:replace="fragments/common/alert-script :: alert-script"></th:block>
+<header th:replace="fragments/header/header :: header"></header>
+<aside th:replace="fragments/sidenav/user/user-sidenav :: sidebar"></aside>
+
+<main>
+  <div class="review-container" th:class="${isViewMode} ? 'review-container view-mode' : 'review-container'">
+    <div class="review-header">
+      <h2 th:text="${isViewMode} ? '면접준비 회고 조회' : '면접준비 회고 작성'">면접준비 회고 작성</h2>
+    </div>
+
+    <div class="routine-info">
+      <h3 th:text="${routine.title}">루틴 제목</h3>
+      <p><strong>설명:</strong> <span th:text="${routine.description ?: '설명 없음'}">설명</span></p>
+      <p><strong>집중 시간:</strong> <span th:text="${routine.focusTime}">60</span>분</p>
+    </div>
+
+    <!-- 작성 모드 -->
+    <form th:if="${!isViewMode}" th:action="@{'/routines/' + ${routine.id} + '/interview-review'}" method="post" id="reviewForm">
+      <input type="hidden" name="sessionId" th:value="${sessionId}" />
+
+      <div id="studySessionsContainer">
+        <div class="study-section">
+          <div class="study-header">
+            <h4>학습 세션 1</h4>
+            <button type="button" class="remove-study" onclick="removeStudySession(this)" style="display: none;">삭제</button>
+          </div>
+
+
+          <label>오늘 공부한 내용</label>
+          <textarea name="studyContents" placeholder="오늘 공부한 주요 내용을 입력하세요" required></textarea>
+
+          <label>어려웠던 부분</label>
+          <textarea name="difficultParts" placeholder="이해하기 어려웠던 부분이나 더 학습이 필요한 부분을 입력하세요" required></textarea>
+
+          <label>다음에 공부할 내용</label>
+          <textarea name="nextStudyPlans" placeholder="다음 학습 계획이나 목표를 입력하세요" required></textarea>
+        </div>
+      </div>
+
+      <div class="button-group">
+        <button type="button" onclick="addStudySession()">+ 학습 세션 추가</button>
+        <button type="submit">저장하기</button>
+        <button type="button" onclick="location.href='/routines'">취소</button>
+      </div>
+    </form>
+
+    <!-- 조회 모드 -->
+    <div th:if="${isViewMode}" class="view-content">
+      <div th:each="review, iterStat : ${existingReviews}" class="study-section view-mode">
+        <div class="study-header">
+          <h4 th:text="'학습 세션 ' + (${iterStat.index} + 1)">학습 세션 1</h4>
+        </div>
+
+        <div class="view-field">
+          <label>기술 분야</label>
+          <div class="field-content" th:text="${review.techCategory}">알고리즘</div>
+        </div>
+
+        <div class="view-field">
+          <label>오늘 공부한 내용</label>
+          <div class="field-content" th:text="${review.studyContent}">학습 내용</div>
+        </div>
+
+        <div class="view-field">
+          <label>어려웠던 부분</label>
+          <div class="field-content" th:text="${review.difficultParts}">어려웠던 부분</div>
+        </div>
+
+        <div class="view-field">
+          <label>다음에 공부할 내용</label>
+          <div class="field-content" th:text="${review.nextStudyPlan}">다음 계획</div>
+        </div>
+      </div>
+
+      <div class="button-group">
+        <button type="button" onclick="location.href='/routines'">목록으로</button>
+      </div>
+    </div>
+  </div>
+</main>
+
+<script>
+  let studySessionCount = 1;
+
+  function addStudySession() {
+    studySessionCount++;
+    const container = document.getElementById('studySessionsContainer');
+    const newSession = document.createElement('div');
+    newSession.className = 'study-section';
+    newSession.innerHTML = `
+      <div class="study-header">
+        <h4>학습 세션 ${studySessionCount}</h4>
+        <button type="button" class="remove-study" onclick="removeStudySession(this)">삭제</button>
+      </div>
+
+
+      <label>오늘 공부한 내용</label>
+      <textarea name="studyContents" placeholder="오늘 공부한 주요 내용을 입력하세요" required></textarea>
+
+      <label>어려웠던 부분</label>
+      <textarea name="difficultParts" placeholder="이해하기 어려웠던 부분이나 더 학습이 필요한 부분을 입력하세요" required></textarea>
+
+      <label>다음에 공부할 내용</label>
+      <textarea name="nextStudyPlans" placeholder="다음 학습 계획이나 목표를 입력하세요" required></textarea>
+    `;
+
+    container.appendChild(newSession);
+
+    // 모든 삭제 버튼 표시
+    document.querySelectorAll('.remove-study').forEach(btn => {
+      btn.style.display = 'inline-block';
+    });
+  }
+
+  function removeStudySession(button) {
+    const sessionDiv = button.closest('.study-section');
+    sessionDiv.remove();
+    studySessionCount--;
+
+    // 세션 번호 재정렬
+    const sessions = document.querySelectorAll('.study-section');
+    sessions.forEach((session, index) => {
+      const header = session.querySelector('h4');
+      header.textContent = `학습 세션 ${index + 1}`;
+    });
+
+    // 세션이 1개만 남으면 삭제 버튼 숨기기
+    if (sessions.length === 1) {
+      sessions[0].querySelector('.remove-study').style.display = 'none';
+    }
+  }
+
+  // 폼 유효성 검사
+  document.getElementById('reviewForm')?.addEventListener('submit', function(e) {
+    const sessions = document.querySelectorAll('.study-section');
+
+    if (sessions.length === 0) {
+      e.preventDefault();
+      alert('최소 하나의 학습 세션을 작성해주세요.');
+      return;
+    }
+
+    // 모든 필수 필드가 채워졌는지 확인
+    let isValid = true;
+    sessions.forEach(session => {
+      const requiredFields = session.querySelectorAll('select[required], textarea[required]');
+      requiredFields.forEach(field => {
+        if (!field.value.trim()) {
+          isValid = false;
+          field.classList.add('error');
+        } else {
+          field.classList.remove('error');
+        }
+      });
+    });
+
+    if (!isValid) {
+      e.preventDefault();
+      alert('모든 필수 항목을 입력해주세요.');
+    } else {
+      // 제출 중 표시
+      this.classList.add('loading');
+      const submitBtn = this.querySelector('button[type="submit"]');
+      submitBtn.textContent = '저장 중...';
+      submitBtn.disabled = true;
+    }
+  });
+
+  // 입력 필드 에러 상태 제거
+  document.addEventListener('input', function(e) {
+    if (e.target.matches('select, textarea')) {
+      e.target.classList.remove('error');
+    }
+  });
+
+  // 페이지 로드 시 사이드바 활성화
+  document.addEventListener('DOMContentLoaded', function() {
+    const routineButton = Array.from(document.querySelectorAll('.nav-link-button'))
+    .find(el => el.textContent.includes('데일리 루틴'));
+    if (routineButton) {
+      routineButton.classList.add('active');
+    }
+  });
+</script>
+
+<th:block th:replace="fragments/common/chatbot-modal :: chatbot"></th:block>
+</body>
+</html>

--- a/src/main/resources/templates/routine/routine-list.html
+++ b/src/main/resources/templates/routine/routine-list.html
@@ -284,7 +284,7 @@
       text-decoration: line-through;
       color: #777;
     }
-    #routineModal, #codingTestModal {
+    #routineModal, #codingTestModal, #interviewModal {
       display: none;
       position: fixed;
       top: 20%;
@@ -297,13 +297,14 @@
       z-index: 2000;
       width: 380px; /* 너비 줄임 */
     }
-    #routineModal h3, #codingTestModal h3 {
+    #routineModal h3, #codingTestModal h3, #interviewModal h3{
       margin-bottom: 16px; /* 여백 줄임 */
       color: #1b2c50;
       font-size: 18px; /* 글씨 크기 줄임 */
     }
     #routineModal input, #routineModal select, #routineModal textarea,
-    #codingTestModal input, #codingTestModal select, #codingTestModal textarea {
+    #codingTestModal input, #codingTestModal select, #codingTestModal textarea,
+    #interviewModal input, #interviewModal select, #interviewModal textarea {
       display: block;
       width: 100%;
       margin-bottom: 12px; /* 여백 줄임 */
@@ -312,27 +313,27 @@
       border-radius: 8px;
       font-size: 14px; /* 글씨 크기 줄임 */
     }
-    #routineModal textarea, #codingTestModal textarea {
+    #routineModal textarea, #codingTestModal textarea, #interviewModal textarea {
       height: 80px; /* 높이 줄임 */
       resize: vertical;
     }
-    #routineModal .button-group, #codingTestModal .button-group {
+    #routineModal .button-group, #codingTestModal .button-group, #interviewModal .button-group {
       display: flex;
       justify-content: flex-end;
       gap: 8px; /* 간격 줄임 */
       margin-top: 16px; /* 여백 줄임 */
     }
-    #routineModal .button-group button, #codingTestModal .button-group button {
+    #routineModal .button-group button, #codingTestModal .button-group button, #interviewModal .button-group button {
       padding: 7px 14px; /* 패딩 줄임 */
       border: none;
       border-radius: 8px;
       cursor: pointer;
       font-size: 13px; /* 글씨 크기 줄임 */
     }
-    #routineModal .button-group button.cancel, #codingTestModal .button-group button.cancel {
+    #routineModal .button-group button.cancel, #codingTestModal .button-group button.cancel, #interviewModal .button-group button.cancel {
       background-color: #e0e0e0;
     }
-    #routineModal .button-group button.submit, #codingTestModal .button-group button.submit {
+    #routineModal .button-group button.submit, #codingTestModal .button-group button.submit, #interviewModal .button-group button.submit {
       background-color: #4e6df2;
       color: white;
     }
@@ -377,7 +378,8 @@
 
     <!-- 고정 루틴 섹션 - 가로 배치 -->
     <div class="fixed-routines-section">
-      <h3>고정 루틴</h3>
+      <h3>필수 루틴</h3>
+
       <div class="fixed-routines-container">
         <div class="fixed-routine-card">
           <div class="fixed-routine-content">
@@ -396,17 +398,7 @@
               <span class="fixed-routine-description">기술 면접 질문 연습</span>
             </div>
           </div>
-          <button class="fixed-routine-start-btn" onclick="location.href='/interview/select'">시작하기</button>
-        </div>
-
-        <div class="fixed-routine-card">
-          <div class="fixed-routine-content">
-            <div class="fixed-routine-info">
-              <span class="fixed-routine-title">채용공고 확인</span>
-              <span class="fixed-routine-description">새로운 채용공고 및 지원 현황 체크</span>
-            </div>
-          </div>
-          <button class="fixed-routine-start-btn" onclick="openJobSearchModal()">시작하기</button>
+          <button class="fixed-routine-start-btn" onclick="openInterviewModal()">시작하기</button>
         </div>
       </div>
     </div>
@@ -435,6 +427,9 @@
               <div th:onclick="'skipRoutine(' + ${routine.id} + ')'">쉬어가기</div>
             </div>
           </div>
+        </div>
+        <div th:if="${activeRoutines == null or activeRoutines.isEmpty()}" class="no-routines">
+          진행 중인 루틴이 없습니다.
         </div>
       </div>
       <!-- 쉬어가기 루틴 목록 -->
@@ -484,6 +479,9 @@
               <!-- 코딩테스트 루틴인 경우 정보보기 추가 -->
               <div th:if="${routine.category != null and #strings.startsWith(routine.category, '코딩테스트 준비')}"
                    th:onclick="'viewCodingReview(' + ${routine.id} + ')'">정보보기</div>
+              <!-- 면접준비 루틴인 경우 정보보기 추가 -->
+              <div th:if="${routine.category != null and #strings.startsWith(routine.category, '면접준비')}"
+                   th:onclick="'viewInterviewReview(' + ${routine.id} + ')'">정보보기</div>
               <div th:onclick="'cancelComplete(' + ${routine.id} + ')'">완료 취소</div>
               <div th:onclick="'deleteRoutine(' + ${routine.id} + ')'">삭제</div>
             </div>
@@ -511,7 +509,7 @@
   </form>
 </div>
 
-
+<!-- 코딩테스트 준비 루틴 모달 -->
 <div id="codingTestModal">
   <h3>코딩테스트 준비 루틴 추가</h3>
   <form id="codingTestForm" th:action="@{/routines}" method="post">
@@ -539,6 +537,33 @@
   </form>
 </div>
 
+<!-- 면접 준비 루틴 모달 -->
+<div id="interviewModal">
+  <h3>면접 준비 루틴 추가</h3>
+  <form id="interviewForm" th:action="@{/routines}" method="post">
+    <input type="hidden" id="interviewTitle" name="title" />
+    <input type="hidden" id="interviewCategory" name="category" />
+
+    <select name="techType" required>
+      <option value="">기술 종류 선택</option>
+      <option value="알고리즘">알고리즘</option>
+      <option value="자료구조">자료구조</option>
+      <option value="데이터베이스">데이터베이스</option>
+      <option value="운영체제">운영체제</option>
+      <option value="네트워크">네트워크</option>
+      <option value="컴퓨터구조">컴퓨터구조</option>
+    </select>
+
+    <textarea name="description" placeholder="상세 설명 (선택사항)"></textarea>
+    <input type="number" name="focusTime" placeholder="집중 시간(분)" min="1" max="180"  required />
+    <input type="number" name="breakTime" placeholder="휴식 시간(분)" min="1" max="60" value="5" required />
+
+    <div class="button-group">
+      <button type="button" class="cancel" onclick="closeInterviewModal()">취소</button>
+      <button type="submit" class="submit">저장</button>
+    </div>
+  </form>
+</div>
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     // 빈 상태 메시지가 여러 개 있으면 첫 번째만 남기고 나머지 제거
@@ -617,6 +642,15 @@
     document.getElementById('codingTestModal').style.display = 'none';
   }
 
+  function openInterviewModal() {
+    document.getElementById('interviewForm').reset();
+    document.getElementById('interviewModal').style.display = 'block';
+  }
+
+  function closeInterviewModal() {
+    document.getElementById('interviewModal').style.display = 'none';
+  }
+
   function openJobSearchModal() {
     document.getElementById('jobSearchForm').reset();
     document.getElementById('jobSearchModal').style.display = 'block';
@@ -626,6 +660,8 @@
     document.getElementById('jobSearchModal').style.display = 'none';
   }
 
+
+  // 코딩테스트 폼 제출 시
   document.getElementById('codingTestForm').addEventListener('submit', function(e) {
     const problemType = document.querySelector('select[name="problemType"]').value;
     if (problemType) {
@@ -635,10 +671,26 @@
     }
   });
 
+  // 면접준비 폼 제출 시
+  document.getElementById('interviewForm').addEventListener('submit', function(e) {
+    const techType = document.querySelector('select[name="techType"]').value;
+    if (techType) {
+      // title을 "면접준비 - 기술종류" 형식으로 저장
+      document.getElementById('interviewTitle').value = `면접준비 - ${techType}`;
+      document.getElementById('interviewCategory').value = `면접준비 - ${techType}`;
+    }
+  });
+
   // 코딩테스트 회고 정보보기
   function viewCodingReview(routineId) {
     location.href = '/routines/' + routineId + '/coding-review';
   }
+
+  // 면접준비 회고 정보보기
+  function viewInterviewReview(routineId) {
+    location.href = '/routines/' + routineId + '/interview-review';
+  }
+
 
   function editRoutine(routineId) {
     fetch(`/routines/${routineId}/edit`)
@@ -839,12 +891,12 @@
         emptyState.className = 'empty-state';
         emptyState.innerHTML = '<p>등록된 데일리 루틴이 없습니다.</p><p>오늘의 루틴을 추가해 보세요!</p>';
 
-        const routineWrapper = document.querySelector('.routine-wrapper');
-        const header = document.querySelector('.routine-header');
+        const activeRoutinesSection = document.querySelector('.active-routines-section');
+        const sectionHeader = activeRoutinesSection.querySelector('.section-header');
 
-        // 헤더 다음에 빈 상태 메시지 삽입
-        if (header && routineWrapper) {
-          routineWrapper.insertBefore(emptyState, header.nextSibling);
+        // 진행루틴에 빈 상태 메시지 삽입
+        if (sectionHeader && activeRoutinesSection) {
+          sectionHeader.insertAdjacentElement('afterend', emptyState);
         }
       }
     } else {

--- a/src/main/resources/templates/routine/timer.html
+++ b/src/main/resources/templates/routine/timer.html
@@ -425,6 +425,11 @@
   let breakSeconds = 0;
   let startTime;
 
+  let actualStartTime = null;    // 실제 타이머 시작 시간
+  let totalPausedTime = 0;       // 총 일시정지 시간 (초)
+  let pauseStartTime = null;     // 일시정지 시작 시간
+  let isActuallyRunning = false; // 실제 진행 중인지 여부
+
   // DOM 요소
   const timerDisplay = document.getElementById('timerDisplay');
   const pauseButton = document.getElementById('pauseButton');
@@ -458,6 +463,9 @@
 
   // 페이지 로드 시 시작 시간 설정
   document.addEventListener('DOMContentLoaded', function() {
+
+    actualStartTime = new Date();
+    isActuallyRunning = true;
     startTime = new Date();
 
     // 휴식 시간 초기화 (페이지 로드 시 한 번만)
@@ -527,19 +535,42 @@
     if (isPaused) {
       // 타이머 재개
       isPaused = false;
+      isActuallyRunning = true;
       pauseIcon.className = 'icon-pause';
-      startTimer();
 
-      // 휴식 타이머 중지
+      // 일시정지 시간 계산 및 누적
+      if (pauseStartTime) {
+        totalPausedTime += Math.floor((new Date() - pauseStartTime) / 1000);
+        pauseStartTime = null;
+      }
+
+      startTimer();
       clearInterval(breakInterval);
       breakInterval = null;
 
     } else {
       // 타이머 일시정지
       pauseTimer();
+      isActuallyRunning = false;
+      pauseStartTime = new Date();
       startBreakTimer();
-
     }
+  }
+
+  function getActualElapsedMinutes() {
+    if (!actualStartTime) return 0;
+
+    const now = new Date();
+    const totalElapsedSeconds = Math.floor((now - actualStartTime) / 1000);
+    const actualElapsedSeconds = totalElapsedSeconds - totalPausedTime;
+
+    // 현재 일시정지 중이면 현재 일시정지 시간도 제외
+    if (isPaused && pauseStartTime) {
+      const currentPauseSeconds = Math.floor((now - pauseStartTime) / 1000);
+      return Math.floor((actualElapsedSeconds - currentPauseSeconds) / 60);
+    }
+
+    return Math.floor(actualElapsedSeconds / 60);
   }
 
   // 타이머 일시정지 함수
@@ -697,6 +728,9 @@
   function completeRoutine(goToNext) {
     confirmModal.style.display = 'none';
 
+    // 실제 진행 시간 계산
+    const actualMinutes = getActualElapsedMinutes();
+
     // 휴식 시간 초기화
     breakSeconds = 0;
 
@@ -705,44 +739,48 @@
       breakInterval = null;
     }
 
-    // 휴식 시간 프로그레스 바 초기화
     if (breakProgressBar) {
       breakProgressBar.style.width = '0%';
     }
 
-    breakProgressBar.style.width = '0%';
-
     window.removeEventListener('beforeunload', beforeUnloadHandler);
 
-    // 코딩테스트 루틴인지 확인
+    // 루틴 카테고리 확인
     const routineCategory = /*[[${routine.category}]]*/ '';
     const isCodingTest = routineCategory && routineCategory.startsWith('코딩테스트 준비');
+    const isInterview = routineCategory && routineCategory.startsWith('면접준비');
 
     // 폼 생성
     const form = document.createElement('form');
     form.method = 'POST';
 
     if (isCodingTest) {
-      // 코딩테스트 루틴이면 코딩 완료 엔드포인트로
       form.action = '/routines/timer/complete-coding';
+    } else if(isInterview){
+      form.action = '/routines/timer/complete-interview';
     } else {
-      // 일반 루틴이면 기존 엔드포인트로
       form.action = '/routines/timer/complete';
     }
 
-    // 세션 ID 추가
+    // 기존 필드들 추가
     const sessionIdInput = document.createElement('input');
     sessionIdInput.type = 'hidden';
     sessionIdInput.name = 'sessionId';
     sessionIdInput.value = pomodoroSessionId;
     form.appendChild(sessionIdInput);
 
-    // 루틴 ID 추가
     const routineIdInput = document.createElement('input');
     routineIdInput.type = 'hidden';
     routineIdInput.name = 'routineId';
     routineIdInput.value = routineId;
     form.appendChild(routineIdInput);
+
+    // 실제 진행 시간 추가
+    const actualTimeInput = document.createElement('input');
+    actualTimeInput.type = 'hidden';
+    actualTimeInput.name = 'actualMinutes';
+    actualTimeInput.value = actualMinutes;
+    form.appendChild(actualTimeInput);
 
     // CSRF 토큰 추가
     const csrfToken = document.querySelector('meta[name="_csrf"]').content;
@@ -758,7 +796,7 @@
     methodInput.value = 'PATCH';
     form.appendChild(methodInput);
 
-    if (goToNext && nextRoutineId && !isCodingTest) {
+    if (goToNext && nextRoutineId && !isCodingTest && !isInterview) {
       const nextInput = document.createElement('input');
       nextInput.type = 'hidden';
       nextInput.name = 'nextRoutineId';
@@ -769,6 +807,8 @@
     document.body.appendChild(form);
     form.submit();
   }
+
+
   function addBreakTimeDisplay() {
     // 기존 휴식 시간 텍스트 요소
     const breakTimeDisplay = document.createElement('div');

--- a/src/main/resources/templates/user/main.html
+++ b/src/main/resources/templates/user/main.html
@@ -432,7 +432,7 @@
 
       <div class="stat-card">
         <div class="stat-header">📚 오늘의 집중시간</div>
-        <div class="stat-value" th:text="${totalFocusMinutes} + '분'">0분</div>
+        <div class="stat-value" th:text="${totalActualFocusMinutes} + '분'">0분</div>
         <div class="stat-subtext">완료된 루틴 기준</div>
       </div>
 


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명focus out 시 타이머 정지되는 로직 삭제

매일매일 해야하는 고정 루틴 추가 - 코딩테스트 준비, 면접준비, 채용공고 사이트 확인

코딩테스트 준비 루틴 - 추가하기 버튼 추가(기존  추가하기 버튼 유지), 버튼 클릭 시 모달창띄워서 문제 종류선택이 가능하게 드롭다운으로 설정 (자료구조, bfs/dfs, 구현, 다익스트라, 트리, 다이나믹 프로그래밍, 탐색, 그리디, 기타), 집중시간, 쉬는 시간, 루틴 제목, 상세 설명까지는 동일, 카테고리 입력 삭제 -> 루틴제목 삭제, 문제종류에 선택된 탭이 title에 입력되도록 수정

루틴 추가 완료 시 -루틴의 카테고리는 '코딩테스트 준비 - (문제종류)' 로 설정, 나머지 데이터는 이전과 동일하게 db에 저장 -> db에 title, catagory 컬럼에는 category에서 선택된 항목 저장되도록 수정

타이머 완료 시 - 내가 풀었던 문제에 대한 회고가 가능하게 내가 푼 풀이, 정답 풀이를 입력 할 수 있는 페이지 (문제 제목, 상세 정보를 따로 기입할 수 있어야 함) 로 이동 (루틴 진행하는 동안 여러 문제를 풀었을 수도 있으니 문항 추가 버튼 추가) 저장하기 버튼을 누르면 루틴 완료처리

완료 된 루틴에서 카테고리가 코딩테스트일 경우에는 (완료취소, 삭제)에 정보보기 추가, 정보보기를 누르면 문제 회고 페이지로 넘어가서 내가 푼 문제를 볼 수 있게 페이지 설정



면접 대비 루틴 - 시작하기 버튼 클릭 시 모달창 팝업, 모달창에 공부할 기술의 종류 선택이 가능하게 드롭다운으로 설정( 문제 종류는 면접대비탭에 있는 카테고리와 동일하게 설정 - 알고리즘, 자료구조, 데이터베이스, 운영체제, 네트워크, 컴퓨터 구조), 상세설명, 집중시간, 쉬는 시간은 이전과 동일

루틴 추가 완료 시 - 루틴의 카테고리는 '면접준비 - (기술종류)'로 설정, 선택된 공부할 기술 종류가 db의 daily_routines의 title,  category에 저장, 나머지 데이터는 이전과 동일하게 저장

타이머 완료 시 - 오늘 공부한 내용 메모할 수 있도록 회고 페이지로 리다이렉팅, 코테준비와 마찬가지로 저장하기 누르면 루틴 완료 처리

완료된 루틴에서 카테고리가 면접준비일 경우에는 '완료취소, 삭제' 탭에 정보보기 추가, 정보보기를 누르면 회고 페이지로 넘어가서 내가 학습한 내용을 볼 수 있게 페이지 설정

루틴 실제 진행시간 반영
 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
