### PR TITLE
feat: 채용공고 페이지 기능 구현 및 알림 이슈 개선중

### DIFF
--- a/src/main/java/com/grepp/codemap/jobposting/controller/JobPostingController.java
+++ b/src/main/java/com/grepp/codemap/jobposting/controller/JobPostingController.java
@@ -2,9 +2,11 @@ package com.grepp.codemap.jobposting.controller;
 
 import com.grepp.codemap.jobposting.domain.JobPosting;
 import com.grepp.codemap.jobposting.dto.JobPostingRequest;
+import com.grepp.codemap.jobposting.dto.JobPostingResponse;
 import com.grepp.codemap.jobposting.service.JobPostingService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,6 +15,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/jobposting")
 @RequiredArgsConstructor
+@Slf4j
 public class JobPostingController {
 
     private final JobPostingService jobPostingService;
@@ -21,23 +24,66 @@ public class JobPostingController {
     @PostMapping
     public ResponseEntity<Void> createJobPosting(@RequestBody JobPostingRequest request, HttpSession session) {
         Long userId = (Long) session.getAttribute("userId");
-        jobPostingService.createJobPosting(userId, request);
-        return ResponseEntity.ok().build();
+        log.info("🔥 POST /jobposting - session userId = {}, request = {}", userId, request);
+
+        if (userId == null) {
+            log.error("❌ 로그인되지 않은 사용자");
+            return ResponseEntity.status(401).build();
+        }
+
+        try {
+            jobPostingService.createJobPosting(userId, request);
+            log.info("✅ 목표기업 등록 성공");
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            log.error("❌ 목표기업 등록 실패: {}", e.getMessage(), e);
+            return ResponseEntity.status(500).build();
+        }
     }
 
     // ✅ 2. 목표기업 목록 조회
     @GetMapping
-    public ResponseEntity<List<JobPosting>> getJobPostings(HttpSession session) {
+    public ResponseEntity<List<JobPostingResponse>> getJobPostings(HttpSession session) {
         Long userId = (Long) session.getAttribute("userId");
-        List<JobPosting> postings = jobPostingService.getJobPostings(userId);
-        return ResponseEntity.ok(postings);
+        log.info("🔥 GET /jobposting - session userId = {}", userId);
+
+        if (userId == null) {
+            log.error("❌ 로그인되지 않은 사용자");
+            return ResponseEntity.status(401).build();
+        }
+
+        try {
+            List<JobPosting> postings = jobPostingService.getJobPostings(userId);
+            List<JobPostingResponse> response = postings.stream()
+                .map(JobPostingResponse::from)
+                .toList();
+
+            log.info("✅ 목표기업 목록 조회 성공: {} 개", response.size());
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            log.error("❌ 목표기업 목록 조회 실패: {}", e.getMessage(), e);
+            return ResponseEntity.status(500).build();
+        }
     }
 
     // ✅ 3. 목표기업 삭제
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteJobPosting(@PathVariable Long id, HttpSession session) {
         Long userId = (Long) session.getAttribute("userId");
-        jobPostingService.deleteJobPosting(id, userId);
-        return ResponseEntity.ok().build();
+        log.info("🔥 DELETE /jobposting/{} - session userId = {}", id, userId);
+
+        if (userId == null) {
+            log.error("❌ 로그인되지 않은 사용자");
+            return ResponseEntity.status(401).build();
+        }
+
+        try {
+            jobPostingService.deleteJobPosting(id, userId);
+            log.info("✅ 목표기업 삭제 성공");
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            log.error("❌ 목표기업 삭제 실패: {}", e.getMessage(), e);
+            return ResponseEntity.status(500).build();
+        }
     }
 }

--- a/src/main/java/com/grepp/codemap/jobposting/controller/JobPostingPageController.java
+++ b/src/main/java/com/grepp/codemap/jobposting/controller/JobPostingPageController.java
@@ -1,6 +1,8 @@
 package com.grepp.codemap.jobposting.controller;
 
 import com.grepp.codemap.jobposting.service.JobPostingService;
+import com.grepp.codemap.user.domain.User;
+import com.grepp.codemap.user.service.UserService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -12,14 +14,18 @@ import org.springframework.web.bind.annotation.GetMapping;
 public class JobPostingPageController {
 
     private final JobPostingService jobPostingService;
+    private final UserService userService;
 
     /**
      * 채용 공고 안내 페이지 출력 (목표기업 리스트 포함)
      */
-    @GetMapping("/jobposting/list")
-    public String showJobPostingList(HttpSession session, Model model) {
+    @GetMapping("/jobposting/page")
+    public String jobpostingPage(Model model, HttpSession session) {
         Long userId = (Long) session.getAttribute("userId");
-        model.addAttribute("jobPostings", jobPostingService.getJobPostings(userId));
-        return "jobposting/jobposting-list";  // templates/jobposting/jobposting-list.html
+        if (userId != null) {
+            User user = userService.getUserById(userId);
+            model.addAttribute("user", user);
+        }
+        return "jobposting/jobposting-list";
     }
 }

--- a/src/main/java/com/grepp/codemap/jobposting/dto/JobPostingRequest.java
+++ b/src/main/java/com/grepp/codemap/jobposting/dto/JobPostingRequest.java
@@ -1,19 +1,39 @@
 package com.grepp.codemap.jobposting.dto;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 
-@Getter
-@NoArgsConstructor
 public class JobPostingRequest {
 
     private String companyName;
-    private LocalDate deadline;
 
-    public JobPostingRequest(String companyName, LocalDate deadline) {
+    @JsonFormat(pattern = "yyyy-MM-dd") // Jackson용
+    @DateTimeFormat(pattern = "yyyy-MM-dd") // Form 데이터용
+    private LocalDate dueDate;
+
+    public JobPostingRequest() {
+    }
+
+    public JobPostingRequest(String companyName, LocalDate dueDate) {
         this.companyName = companyName;
-        this.deadline = deadline;
+        this.dueDate = dueDate;
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
+    }
+
+    public LocalDate getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(LocalDate dueDate) {
+        this.dueDate = dueDate;
     }
 }

--- a/src/main/java/com/grepp/codemap/jobposting/dto/JobPostingResponse.java
+++ b/src/main/java/com/grepp/codemap/jobposting/dto/JobPostingResponse.java
@@ -1,5 +1,30 @@
 package com.grepp.codemap.jobposting.dto;
 
+import com.grepp.codemap.jobposting.domain.JobPosting;
+import java.time.LocalDate;
+
 public class JobPostingResponse {
 
+    private Long id;
+    private String title;
+    private LocalDate dueDate;
+
+    public JobPostingResponse(Long id, String title, LocalDate dueDate) {
+        this.id = id;
+        this.title = title;
+        this.dueDate = dueDate;
+    }
+
+    public static JobPostingResponse from(JobPosting posting) {
+        return new JobPostingResponse(
+            posting.getId(),
+            posting.getTitle(),
+            posting.getDueDate()
+        );
+    }
+
+    // getter들 추가
+    public Long getId() { return id; }
+    public String getTitle() { return title; }
+    public LocalDate getDueDate() { return dueDate; }
 }

--- a/src/main/java/com/grepp/codemap/jobposting/repository/JobPostingRepository.java
+++ b/src/main/java/com/grepp/codemap/jobposting/repository/JobPostingRepository.java
@@ -2,15 +2,24 @@ package com.grepp.codemap.jobposting.repository;
 
 import com.grepp.codemap.jobposting.domain.JobPosting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface JobPostingRepository extends JpaRepository<JobPosting, Long> {
 
-    // ✅ 사용자의 모든 목표기업 조회
-    List<JobPosting> findByUser_Id(Long userId);
+    // ✅ 사용자의 모든 목표기업 조회 (삭제되지 않은 것만)
+    List<JobPosting> findByUser_IdAndIsDeletedFalse(Long userId);
 
-    // ✅ 특정 사용자의 목표기업 단건 조회
-    Optional<JobPosting> findByIdAndUser_Id(Long id, Long userId);
+    // ✅ 특정 사용자의 목표기업 단건 조회 (삭제되지 않은 것만)
+    Optional<JobPosting> findByIdAndUser_IdAndIsDeletedFalse(Long id, Long userId);
+
+    // ✅ 사용자의 목표기업 목록 조회 (삭제되지 않은 것만)
+    List<JobPosting> findByUser_IdAndIsTargetTrueAndIsDeletedFalse(Long userId);
+
+    // ✅ 특정 사용자의 목표기업 개수 조회
+    @Query("SELECT COUNT(jp) FROM JobPosting jp WHERE jp.user.id = :userId AND jp.isTarget = true AND jp.isDeleted = false")
+    long countTargetJobPostingsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/grepp/codemap/jobposting/service/JobPostingService.java
+++ b/src/main/java/com/grepp/codemap/jobposting/service/JobPostingService.java
@@ -5,44 +5,68 @@ import com.grepp.codemap.jobposting.dto.JobPostingRequest;
 import com.grepp.codemap.jobposting.repository.JobPostingRepository;
 import com.grepp.codemap.user.domain.User;
 import com.grepp.codemap.user.repository.UserRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
+@Transactional
+@Slf4j
 public class JobPostingService {
 
     private final JobPostingRepository jobPostingRepository;
     private final UserRepository userRepository;
 
-    // ✅ 1. 목표기업 등록
+    /**
+     * 목표기업 등록
+     */
     public void createJobPosting(Long userId, JobPostingRequest request) {
+        log.info("목표기업 등록 시작 - userId: {}, request: {}", userId, request.getCompanyName());
+
+        // 1. 사용자 조회
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
+        // 2. JobPosting 엔티티 생성
         JobPosting jobPosting = JobPosting.builder()
             .user(user)
-            .title(request.getCompanyName())
-            .dueDate(request.getDeadline())
-            .isTarget(true)
+            .title(request.getCompanyName())  // companyName을 title로 저장
+            .dueDate(request.getDueDate())
+            .isTarget(true)  // 목표기업으로 설정
+            .isDeleted(false)  // 삭제되지 않은 상태
             .build();
 
+        // 3. 저장
         jobPostingRepository.save(jobPosting);
+        log.info("목표기업 등록 완료 - title: {}", request.getCompanyName());
     }
 
-    // ✅ 2. 목표기업 목록 조회
+    /**
+     * 사용자의 목표기업 목록 조회
+     */
+    @Transactional(readOnly = true)
     public List<JobPosting> getJobPostings(Long userId) {
-        return jobPostingRepository.findByUser_Id(userId);
+        log.info("목표기업 목록 조회 - userId: {}", userId);
+        return jobPostingRepository.findByUser_IdAndIsTargetTrueAndIsDeletedFalse(userId);
     }
 
-    // ✅ 3. 목표기업 삭제
-    public void deleteJobPosting(Long postingId, Long userId) {
-        JobPosting posting = jobPostingRepository.findByIdAndUser_Id(postingId, userId)
+    /**
+     * 목표기업 삭제 (Soft Delete)
+     */
+    public void deleteJobPosting(Long jobPostingId, Long userId) {
+        log.info("목표기업 삭제 시작 - jobPostingId: {}, userId: {}", jobPostingId, userId);
+
+        JobPosting jobPosting = jobPostingRepository.findByIdAndUser_IdAndIsDeletedFalse(jobPostingId, userId)
             .orElseThrow(() -> new IllegalArgumentException("해당 공고를 찾을 수 없습니다."));
-        jobPostingRepository.delete(posting);
+
+        // Soft Delete
+        jobPosting.setDeleted(true);
+        jobPostingRepository.save(jobPosting);
+
+        log.info("목표기업 삭제 완료 - title: {}", jobPosting.getTitle());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,3 +36,7 @@ spring.thymeleaf.prefix=classpath:/templates/
 spring.thymeleaf.suffix=.html
 spring.thymeleaf.cache=false
 spring.mvc.hiddenmethod.filter.enabled=true
+
+
+spring.devtools.restart.enabled=true
+spring.devtools.livereload.enabled=true

--- a/src/main/resources/templates/fragments/common/alert-script.html
+++ b/src/main/resources/templates/fragments/common/alert-script.html
@@ -14,69 +14,187 @@
     .blink {
       animation: blink-animation 1s infinite;
     }
+
+    /* ✅ 새로운 header 구조에 맞춘 스타일 */
+    #notification-popup {
+      display: none;
+      position: absolute;
+      top: 36px;
+      right: 0;
+      background-color: #fff;
+      border: 1px solid #ccc;
+      border-radius: 8px;
+      padding: 12px;
+      box-shadow: 0px 2px 12px rgba(0,0,0,0.15);
+      width: 240px;
+      z-index: 10000;
+      max-height: 300px;
+      overflow-y: auto;
+    }
+
+    #notification-popup p {
+      margin: 0;
+      padding: 8px 0;
+      border-bottom: 1px solid #f0f0f0;
+      font-size: 14px;
+      line-height: 1.4;
+    }
+
+    #notification-popup p:last-child {
+      border-bottom: none;
+    }
+
+    /* ✅ 알림 아이콘 스타일 */
+    #notification-icon {
+      position: relative;
+      cursor: pointer;
+      transition: transform 0.2s ease;
+    }
+
+    #notification-icon:hover {
+      transform: scale(1.1);
+    }
   </style>
 
   <script th:inline="javascript">
     /*<![CDATA[*/
-    window.addEventListener('load', () => {
+    function setupNotificationScript() {
+      // ✅ 중복 초기화 방지
+      if (window.notificationSystemInitialized) {
+        console.log("🔔 알림 시스템이 이미 초기화되었습니다.");
+        return;
+      }
+
       const icon = document.getElementById('notification-icon');
       const popup = document.getElementById('notification-popup');
 
-      // ✅ 아이콘 클릭 시 항상 팝업 표시되도록 기본 핸들러 등록
-      if (icon && popup) {
-        icon.addEventListener('click', () => {
-          if (popup.innerHTML.trim() !== '') {
-            // 기존 알림 내용이 있다면 그냥 토글
-            popup.style.display = popup.style.display === 'none' ? 'block' : 'none';
-          } else {
-            // 알림이 없으면 기본 메시지 출력
-            popup.innerHTML = '<p>🔕 아직 알림이 없습니다.</p>';
-            popup.style.display = 'block';
-          }
-        });
+      if (!icon || !popup) {
+        console.warn("🔕 알림 요소를 찾을 수 없습니다.");
+        console.log("Icon:", icon, "Popup:", popup);
+        return;
       }
 
-      // ✅ SSE 연결
-      const eventSource = new EventSource('/sse/alerts');
+      console.log("✅ 알림 요소 찾음:", { icon, popup });
 
-      eventSource.addEventListener('ALERT', (event) => {
-        const todos = JSON.parse(event.data);
-        console.log("📩 수신된 알림:", todos);
+      // ✅ 클릭 이벤트 리스너
+      icon.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
 
-        if (!Array.isArray(todos) || todos.length === 0) return;
+        console.log("🔔 알림 아이콘 클릭됨");
 
-        // ✅ 아이콘 깜빡임
-        if (icon) icon.classList.add('blink');
+        // 현재 팝업 상태 확인
+        const isVisible = popup.style.display === 'block';
 
-        // ✅ 화면 점멸
-        document.body.style.animation = "flash 0.3s alternate 6";
-
-        // ✅ 음성 알림 (첫 클릭 시만 재생)
-        document.addEventListener('click', function handler() {
-          const audio = new Audio('/sounds/alert.mp3');
-          audio.play().catch(e => console.warn("🔇 자동 재생 차단:", e));
-          document.removeEventListener('click', handler);
-        });
-
-        // ✅ 팝업 내용 갱신
-        popup.innerHTML = todos.map(todo =>
-            `<p>🕐 <strong>${todo.title}</strong><br/><span style="font-size: 12px;">시작 10분 전입니다.</span></p>`
-        ).join('');
-
-        // 팝업 열려있으면 자동 갱신된 내용 보이도록 유지
-        if (popup.style.display !== 'none') {
+        if (isVisible) {
+          popup.style.display = 'none';
+          console.log("팝업 숨김");
+        } else {
+          // 팝업에 내용이 있는지 확인
+          if (popup.innerHTML.trim() === '') {
+            popup.innerHTML = '<p>🔕 아직 알림이 없습니다.</p>';
+          }
           popup.style.display = 'block';
+          console.log("팝업 표시", popup.innerHTML);
         }
       });
 
-      eventSource.addEventListener('CONNECTED', () => {
-        console.log("✅ SSE 연결됨");
+      // ✅ 외부 클릭 시 팝업 닫기
+      document.addEventListener('click', function(e) {
+        if (!icon.contains(e.target) && !popup.contains(e.target)) {
+          popup.style.display = 'none';
+        }
       });
 
-      eventSource.onerror = (e) => {
-        console.error("❌ SSE 연결 오류:", e);
-        eventSource.close();
-      };
+      // ✅ SSE 연결
+      let eventSource = null;
+
+      try {
+        // 기존 연결이 있으면 닫기
+        if (window.notificationEventSource) {
+          window.notificationEventSource.close();
+        }
+
+        eventSource = new EventSource('/sse/alerts');
+        window.notificationEventSource = eventSource;
+
+        eventSource.addEventListener('ALERT', function(event) {
+          try {
+            console.log("📩 SSE 이벤트 수신:", event.data);
+
+            const todos = JSON.parse(event.data);
+
+            if (!Array.isArray(todos) || todos.length === 0) {
+              console.log("빈 알림 데이터");
+              return;
+            }
+
+            console.log("처리할 알림:", todos);
+
+            // ✅ 시각적 효과
+            icon.classList.add('blink');
+            document.body.style.animation = "flash 0.3s alternate 6";
+
+            // ✅ 사운드 재생 (사용자 상호작용 후)
+            const playSound = function() {
+              const audio = new Audio('/sounds/alert.mp3');
+              audio.play().catch(e => console.warn("🔇 사운드 재생 실패:", e));
+              document.removeEventListener('click', playSound);
+            };
+            document.addEventListener('click', playSound, { once: true });
+
+            // ✅ 팝업 내용 업데이트
+            popup.innerHTML = todos.map(todo =>
+                `<p>🕐 <strong>${todo.title}</strong><br/><span style="font-size: 12px; color: #666;">시작 10분 전입니다.</span></p>`
+            ).join('');
+
+            // ✅ 팝업 자동 표시
+            popup.style.display = 'block';
+
+            // ✅ 깜빡임 효과 제거
+            setTimeout(() => {
+              icon.classList.remove('blink');
+            }, 3000);
+
+          } catch (error) {
+            console.error("❌ 알림 데이터 파싱 오류:", error, event.data);
+          }
+        });
+
+        eventSource.addEventListener('CONNECTED', function() {
+          console.log("✅ SSE 연결 성공");
+        });
+
+        eventSource.addEventListener('error', function(e) {
+          console.error("❌ SSE 연결 오류:", e);
+          if (eventSource) {
+            eventSource.close();
+            window.notificationEventSource = null;
+          }
+        });
+
+      } catch (error) {
+        console.error("❌ SSE 초기화 오류:", error);
+      }
+
+      // ✅ 초기화 완료
+      window.notificationSystemInitialized = true;
+      console.log("✅ 알림 시스템 초기화 완료");
+    }
+
+    // ✅ DOM 준비 후 실행
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', setupNotificationScript);
+    } else {
+      // 이미 로드된 경우 즉시 실행
+      setupNotificationScript();
+    }
+
+    // ✅ 페이지 언로드 시 정리
+    window.addEventListener('beforeunload', function() {
+      if (window.notificationEventSource) {
+        window.notificationEventSource.close();
+      }
     });
     /*]]>*/
   </script>

--- a/src/main/resources/templates/fragments/header/header.html
+++ b/src/main/resources/templates/fragments/header/header.html
@@ -1,4 +1,4 @@
-<!-- ✅ 개선된 헤더 Fragment (알림 기능 제거) -->
+<!-- ✅ 개선된 헤더 Fragment -->
 <div th:fragment="header" class="header">
   <!-- 헤더 배경 효과 -->
   <div class="header-background">
@@ -37,7 +37,14 @@
   <div class="header-center"></div>
 
   <!-- 우측 사용자 정보 영역 -->
-  <div class="header-actions">
+  <div class="header-actions" style="display: flex; align-items: center; gap: 16px; margin-right: 24px;">
+
+    <!-- ✅ 알림 아이콘 (기존 구조와 호환되도록) -->
+    <div class="notification-wrapper" style="position: relative; display: flex; align-items: center;">
+      <span id="notification-icon" style="font-size: 20px; cursor: pointer;">🔔</span>
+      <div id="notification-popup"></div> <!-- 인라인 스타일 제거 -->
+    </div>
+
     <!-- 사용자 정보 -->
     <div class="user-info">
       <div class="user-avatar-wrapper">
@@ -67,11 +74,11 @@
   </div>
 </div>
 
-<!-- ✅ 개선된 헤더 스크립트 (알림 기능 제거) -->
+<!-- ✅ 헤더 관련 스크립트 -->
 <script th:inline="javascript">
   /*<![CDATA[*/
   document.addEventListener('DOMContentLoaded', function() {
-    // 헤더 고정 강화
+    // 헤더 고정
     const header = document.querySelector('.header');
     if (header) {
       header.style.position = 'fixed';
@@ -82,7 +89,7 @@
       header.style.width = '100%';
     }
 
-    // 사이드바 토글 함수
+    // 사이드바 토글
     window.toggleSidebar = function() {
       const sidebar = document.querySelector('.sidebar');
       const toggleBtn = document.querySelector('.sidebar-toggle');
@@ -103,7 +110,7 @@
       }
     };
 
-    // 스크롤에 따른 헤더 효과
+    // 스크롤 효과
     let lastScrollY = window.scrollY;
     let ticking = false;
 
@@ -130,12 +137,11 @@
       }
     });
 
-    // 리사이즈 이벤트 처리
+    // 리사이즈
     let resizeTimer;
     window.addEventListener('resize', function() {
       clearTimeout(resizeTimer);
       resizeTimer = setTimeout(function() {
-        // 모바일에서 데스크톱으로 전환시 사이드바 닫기
         if (window.innerWidth > 768) {
           const sidebar = document.querySelector('.sidebar');
           const toggleBtn = document.querySelector('.sidebar-toggle');
@@ -150,3 +156,6 @@
   });
   /*]]>*/
 </script>
+
+<!-- ✅ 알림 스크립트 연결 -->
+<th:block th:replace="~{fragments/common/alert-script :: alert-script}" />

--- a/src/main/resources/templates/fragments/sidenav/user/user-sidenav.html
+++ b/src/main/resources/templates/fragments/sidenav/user/user-sidenav.html
@@ -27,7 +27,7 @@
     </a>
 
     <!-- 채용공고 -->
-    <a th:href="@{/jobposting/list}" class="nav-item" data-nav="jobposting">
+    <a th:href="@{/jobposting/page}" class="nav-item" data-nav="jobposting">
       <div class="nav-icon">💼</div>
       <span class="nav-text">채용공고</span>
       <div class="nav-indicator"></div>
@@ -71,7 +71,7 @@
       '/todos': 'todos',
       '/todos/calender': 'todos',
       '/routines': 'routines',
-      '/jobposting/list': 'jobposting',
+      '/jobposting/page': 'jobposting',
       '/interview/select': 'interview',
       '/mypage/stats': 'stats',
       '/settings': 'settings'

--- a/src/main/resources/templates/jobposting/jobposting-list.html
+++ b/src/main/resources/templates/jobposting/jobposting-list.html
@@ -1,297 +1,647 @@
 <!DOCTYPE html>
-<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>채용 공고 안내</title>
+  <title>채용공고 - 목표기업 관리</title>
 
-  <link rel="stylesheet" th:href="@{/css/fragment/header.css}" />
-  <link rel="stylesheet" th:href="@{/css/fragment/sidenav.css}" />
+  <!-- ✅ CSRF 토큰 메타 추가 -->
+  <meta name="_csrf" th:content="${_csrf.token}"/>
+  <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
 
-  <!-- ✅ Pretendard 폰트 CDN -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pretendard@1.3.6/dist/web/static/pretendard.css" />
-</head>
+  <!-- ✅ 공통 스타일 -->
+  <link rel="stylesheet" th:href="@{/css/fragment/header.css}"/>
+  <link rel="stylesheet" th:href="@{/css/fragment/sidenav.css}"/>
+  <link rel="stylesheet" th:href="@{/css/fragment/chatbot.css}"/>
 
   <style>
+    body {
+      margin: 0;
+      padding: 0;
+      background-color: #F8F9FA;
+      font-family: "Pretendard", sans-serif;
+    }
+
+    header {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 116px;
+      z-index: 1000;
+      background: white;
+    }
+
+    aside {
+      position: fixed;
+      top: 116px;
+      left: 0;
+      width: 250px;
+      height: calc(100vh - 116px);
+      z-index: 900;
+      background: white;
+    }
+
     main {
-      margin-left: 287px;
-      padding: 100px 40px 40px 40px;
+      margin-left: 280px;
+      margin-top: 100px;
+      padding: 30px;
+      min-height: calc(100vh - 100px);
       background-color: #f8f9fa;
-      min-height: 100vh;
-      font-family: 'Pretendard', sans-serif;
+    }
+
+    /* D-Day 알림 바 - 모든 페이지에 표시 */
+    .dday-notification {
+      position: fixed;
+      top: 116px;
+      left: 0;
+      right: 0;
+      background: linear-gradient(90deg, #ff6b6b, #ee5a24);
+      color: white;
+      padding: 12px 20px;
+      z-index: 999;
+      box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+      animation: slideDown 0.5s ease-out;
+      display: none;
+    }
+
+    .dday-notification.show {
+      display: block;
+    }
+
+    @keyframes slideDown {
+      from { transform: translateY(-100%); }
+      to { transform: translateY(0); }
+    }
+
+    .dday-content {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 20px;
+      font-weight: bold;
+      font-size: 14px;
+    }
+
+    .dday-urgent {
+      animation: pulse 2s infinite;
+    }
+
+    @keyframes pulse {
+      0% { opacity: 1; }
+      50% { opacity: 0.7; }
+      100% { opacity: 1; }
+    }
+
+    /* 메인 컨테이너 */
+    .jobposting-container {
+      background: #ffffff;
+      border-radius: 16px;
+      padding: 32px;
+      max-width: 1000px;
+      margin: 0 auto;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.05);
     }
 
     .page-title {
-      font-size: 28px;
+      font-size: 24px;
       font-weight: 700;
-      margin-bottom: 24px;
-    }
-
-    .add-button {
-      margin-bottom: 24px;
-      padding: 10px 18px;
-      background-color: #3b82f6;
-      color: white;
-      font-size: 14px;
-      border: none;
-      border-radius: 8px;
-      cursor: pointer;
-    }
-
-    .posting-table {
-      width: 100%;
-      border-collapse: collapse;
-      background: #fff;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-      border-radius: 12px;
-      overflow: hidden;
-    }
-
-    .posting-table th,
-    .posting-table td {
-      padding: 16px;
-      text-align: left;
-      border-bottom: 1px solid #eee;
-    }
-
-    .posting-table th {
-      background-color: #f1f3f5;
-      font-weight: 600;
-    }
-
-    .posting-table tr:hover {
-      background-color: #f8f9fa;
-    }
-
-    .actions button {
-      margin-right: 8px;
-      padding: 6px 12px;
-      border: none;
-      border-radius: 4px;
-      background-color: #74b9ff;
-      color: #fff;
-      cursor: pointer;
-    }
-
-    .actions button.delete {
-      background-color: #ff7675;
-    }
-
-    #jobPostingModal {
-      display: none;
-      position: fixed;
-      top: 18%;
-      left: 50%;
-      transform: translateX(-50%);
-      background: white;
-      padding: 30px;
-      width: 420px;
-      border-radius: 16px;
-      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-      z-index: 9999;
-    }
-
-    #jobPostingModal input {
-      width: 100%;
-      padding: 12px;
-      margin-bottom: 12px;
-      font-family: "Pretendard", sans-serif;
-      font-size: 15px;
-      border-radius: 8px;
-      border: 1px solid #d1d5db;
-    }
-
-    .submit-button {
-      background-color: #3b82f6;
-      color: white;
-      border: none;
-    }
-
-    .submit-button:hover {
-      background-color: #2563eb;
-    }
-
-    .cancel-button {
-      background-color: #f3f4f6;
       color: #1f2937;
-      border: none;
-    }
-
-    .cancel-button:hover {
-      background-color: #e5e7eb;
-    }
-
-    #jobPostingModal button {
-      width: 100%;
-      padding: 12px;
-      margin-top: 10px;
-      font-family: "Pretendard", sans-serif;
-      font-size: 15px;
-      border-radius: 8px;
-      cursor: pointer;
-    }
-
-    #jobDeleteModal {
-      display: none;
-      position: fixed;
-      top: 25%;
-      left: 50%;
-      transform: translateX(-50%);
-      background: #ffffff;
-      padding: 30px;
-      border-radius: 16px;
-      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-      z-index: 2000;
-      width: 400px;
+      margin-bottom: 8px;
       text-align: center;
-      font-family: "Pretendard", sans-serif;
     }
 
-    #jobDeleteModal h2 {
-      margin-bottom: 20px;
-      font-size: 22px;
-      font-weight: 700;
-      color: #1f2937;
-    }
-
-    .modal-message {
+    .page-subtitle {
       font-size: 16px;
-      color: #374151;
-      margin-bottom: 30px;
+      color: #6b7280;
+      margin-bottom: 32px;
+      text-align: center;
     }
 
-    .button-group {
+    /* 채용사이트 링크 섹션 */
+    .job-sites-section {
+      background: #f8fafc;
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 32px;
+    }
+
+    .section-title {
+      font-size: 20px;
+      font-weight: 600;
+      color: #1f2937;
+      margin-bottom: 16px;
       display: flex;
-      justify-content: center;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .job-sites-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
       gap: 16px;
     }
 
-    .delete-button,
-    .cancel-button {
-      padding: 12px 24px;
-      border-radius: 10px;
-      font-size: 15px;
-      font-weight: 500;
-      border: none;
-      cursor: pointer;
-      width: 120px;
+    .job-site-card {
+      background: white;
+      border-radius: 12px;
+      padding: 20px;
+      text-decoration: none;
+      color: inherit;
+      border: 2px solid #e5e7eb;
+      transition: all 0.3s ease;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 12px;
     }
 
-    .delete-button {
-      background-color: #dbeafe;
-      color: #1e3a8a;
+    .job-site-card:hover {
+      border-color: #6366f1;
+      transform: translateY(-2px);
+      box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
     }
 
-    .delete-button:hover {
-      background-color: #dc2626;
+    .job-site-logo {
+      font-size: 32px;
+      margin-bottom: 8px;
+    }
+
+    .job-site-name {
+      font-size: 16px;
+      font-weight: 600;
+      color: #1f2937;
+    }
+
+    .job-site-desc {
+      font-size: 14px;
+      color: #6b7280;
+      text-align: center;
+    }
+
+    /* 목표기업 관리 섹션 */
+    .target-companies-section {
+      background: #f0f9ff;
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 32px;
+    }
+
+    .add-company-form {
+      background: white;
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 24px;
+      border: 2px solid #e0f2fe;
+    }
+
+    .form-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr auto;
+      gap: 16px;
+      align-items: end;
+    }
+
+    .form-group {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .form-label {
+      font-size: 14px;
+      font-weight: 600;
+      color: #1f2937;
+    }
+
+    .form-input {
+      padding: 12px 16px;
+      border: 2px solid #e5e7eb;
+      border-radius: 8px;
+      font-size: 16px;
+      transition: border-color 0.3s;
+    }
+
+    .form-input:focus {
+      outline: none;
+      border-color: #6366f1;
+    }
+
+    .add-btn {
+      background: #6366f1;
       color: white;
+      border: none;
+      padding: 12px 24px;
+      border-radius: 8px;
+      font-size: 16px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background-color 0.3s;
     }
 
-    .cancel-button:hover {
-      background-color: #e5e7eb;
+    .add-btn:hover {
+      background: #5048e5;
+    }
+
+    /* 목표기업 리스트 */
+    .company-list {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .company-item {
+      background: white;
+      border-radius: 12px;
+      padding: 20px;
+      border: 2px solid #e0f2fe;
+      display: flex;
+      justify-content: between;
+      align-items: center;
+      position: relative;
+    }
+
+    .company-info {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      flex: 1;
+    }
+
+    .company-icon {
+      font-size: 24px;
+      background: #f0f9ff;
+      padding: 12px;
+      border-radius: 50%;
+    }
+
+    .company-details {
+      flex: 1;
+    }
+
+    .company-name {
+      font-size: 18px;
+      font-weight: 600;
+      color: #1f2937;
+      margin-bottom: 4px;
+    }
+
+    .company-deadline {
+      font-size: 14px;
+      color: #6b7280;
+    }
+
+    .dday-badge {
+      padding: 8px 16px;
+      border-radius: 20px;
+      font-size: 14px;
+      font-weight: 600;
+      margin-right: 16px;
+    }
+
+    .dday-urgent {
+      background: #fee2e2;
+      color: #dc2626;
+    }
+
+    .dday-warning {
+      background: #fef3c7;
+      color: #d97706;
+    }
+
+    .dday-normal {
+      background: #d1fae5;
+      color: #065f46;
+    }
+
+    .delete-btn {
+      background: #fee2e2;
+      color: #dc2626;
+      border: none;
+      padding: 8px 12px;
+      border-radius: 6px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: all 0.3s;
+    }
+
+    .delete-btn:hover {
+      background: #fecaca;
+    }
+
+    .empty-state {
+      text-align: center;
+      padding: 40px;
+      color: #6b7280;
+    }
+
+    .empty-icon {
+      font-size: 48px;
+      margin-bottom: 16px;
+    }
+
+    /* 반응형 */
+    @media (max-width: 768px) {
+      main {
+        margin-left: 0;
+        padding: 20px;
+      }
+
+      .form-grid {
+        grid-template-columns: 1fr;
+        gap: 16px;
+      }
+
+      .job-sites-grid {
+        grid-template-columns: repeat(2, 1fr);
+      }
+
+      .company-item {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 16px;
+      }
+
+      .company-info {
+        width: 100%;
+      }
+
+      .dday-badge {
+        margin-right: 0;
+        margin-bottom: 8px;
+      }
+    }
+
+    /* D-Day 알림이 있을 때 메인 콘텐츠 마진 조정 */
+    main.with-dday {
+      margin-top: 150px;
     }
   </style>
 </head>
 
 <body>
-<!-- ✅ 헤더 fragment 삽입 -->
-<div th:replace="~{fragments/header/header :: header}"></div>
+<header th:replace="fragments/header/header :: header"></header>
+<aside th:replace="fragments/sidenav/user/user-sidenav :: sidebar"></aside>
+<th:block th:replace="fragments/common/alert-script :: alert-script"></th:block>
 
-<!-- ✅ 사이드네비 fragment 삽입 -->
-<div th:replace="~{fragments/sidenav/user/user-sidenav :: sidebar}"></div>
-
-<main>
-  <div class="page-title">채용 공고 안내</div>
-
-  <button onclick="openJobPostingModal()" class="add-button">+ 목표 기업 등록</button>
-
-  <div id="jobPostingModal">
-    <h2 style="margin-bottom: 16px;">🎯 목표 기업 등록</h2>
-    <form th:action="@{/jobposting}" method="post">
-      <input type="text" name="title" placeholder="기업명 또는 공고 제목" required />
-      <input type="text" name="site" placeholder="공고 사이트 (예: 원티드)" required />
-      <input type="url" name="url" placeholder="채용공고 링크 (URL)" required />
-      <label for="dueDate" class="input-label">📅 마감일</label>
-      <input type="date" id="dueDate" name="dueDate" required />
-      <button type="submit" class="submit-button">등록</button>
-      <button type="button" class="cancel-button" onclick="closeJobPostingModal()">취소</button>
-    </form>
+<!-- D-Day 알림 바 -->
+<div id="ddayNotification" class="dday-notification">
+  <div class="dday-content">
+    <span id="ddayText"></span>
   </div>
+</div>
 
-  <div id="jobDeleteModal">
-    <h2>채용 공고 삭제</h2>
-    <div class="modal-message">정말로 이 채용 공고를 삭제하시겠습니까?</div>
-    <div class="button-group">
-      <button id="confirmJobDeleteBtn" class="delete-button">삭제</button>
-      <button class="cancel-button" onclick="closeJobDeleteModal()">취소</button>
+<main id="mainContent">
+  <div class="jobposting-container">
+    <h1 class="page-title">💼 채용공고 & 목표기업 관리</h1>
+    <p class="page-subtitle">채용 사이트를 확인하고 목표 기업의 마감일을 관리해보세요</p>
+
+    <!-- 채용사이트 링크 섹션 -->
+    <div class="job-sites-section">
+      <h2 class="section-title">🔗 주요 채용 사이트</h2>
+      <div class="job-sites-grid">
+        <a href="https://www.wanted.co.kr" target="_blank" class="job-site-card">
+          <div class="job-site-logo">🎯</div>
+          <div class="job-site-name">원티드</div>
+          <div class="job-site-desc">개발자 맞춤 채용정보</div>
+        </a>
+        <a href="https://www.saramin.co.kr" target="_blank" class="job-site-card">
+          <div class="job-site-logo">👥</div>
+          <div class="job-site-name">사람인</div>
+          <div class="job-site-desc">대한민국 대표 채용사이트</div>
+        </a>
+        <a href="https://www.jobkorea.co.kr" target="_blank" class="job-site-card">
+          <div class="job-site-logo">🏢</div>
+          <div class="job-site-name">잡코리아</div>
+          <div class="job-site-desc">다양한 기업 정보</div>
+        </a>
+        <a href="https://www.incruit.com" target="_blank" class="job-site-card">
+          <div class="job-site-logo">📋</div>
+          <div class="job-site-name">인크루트</div>
+          <div class="job-site-desc">신입/경력 채용정보</div>
+        </a>
+        <a href="https://programmers.co.kr/job" target="_blank" class="job-site-card">
+          <div class="job-site-logo">💻</div>
+          <div class="job-site-name">프로그래머스</div>
+          <div class="job-site-desc">개발자 전문 채용</div>
+        </a>
+        <a href="https://www.rocketpunch.com" target="_blank" class="job-site-card">
+          <div class="job-site-logo">🚀</div>
+          <div class="job-site-name">로켓펀치</div>
+          <div class="job-site-desc">스타트업 채용정보</div>
+        </a>
+        <a href="https://www.jumpit.co.kr" target="_blank" class="job-site-card">
+          <div class="job-site-logo">⚡</div>
+          <div class="job-site-name">점핏</div>
+          <div class="job-site-desc">IT 개발자 전문 채용</div>
+        </a>
+        <a href="https://careerly.co.kr" target="_blank" class="job-site-card">
+          <div class="job-site-logo">💼</div>
+          <div class="job-site-name">커리어리</div>
+          <div class="job-site-desc">커리어 성장 플랫폼</div>
+        </a>
+      </div>
+    </div>
+
+    <!-- 목표기업 관리 섹션 -->
+    <div class="target-companies-section">
+      <h2 class="section-title">🎯 목표기업 관리</h2>
+
+      <!-- 목표기업 추가 폼 -->
+      <div class="add-company-form">
+        <form id="addCompanyForm">
+          <div class="form-grid">
+            <div class="form-group">
+              <label class="form-label" for="companyName">기업명</label>
+              <input type="text" id="companyName" name="companyName" class="form-input" placeholder="목표 기업명을 입력하세요" required>
+            </div>
+            <div class="form-group">
+              <label class="form-label" for="deadline">마감일</label>
+              <input type="date" id="deadline" name="deadline" class="form-input" required>
+            </div>
+            <button type="submit" class="add-btn">📌 추가</button>
+          </div>
+        </form>
+      </div>
+
+      <!-- 목표기업 리스트 -->
+      <div id="companyList" class="company-list">
+        <!-- 여기에 목표기업들이 동적으로 추가됩니다 -->
+      </div>
     </div>
   </div>
-
-  <table class="posting-table">
-    <thead>
-    <tr>
-      <th>기업명</th>
-      <th>채용사이트</th>
-      <th>마감일</th>
-      <th>목표기업 여부</th>
-      <th>기능</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr th:each="post : ${jobPosting}">
-      <td th:text="${post.title}">카카오</td>
-      <td><a th:href="${post.url}" target="_blank" th:text="${post.site}">원티드</a></td>
-      <td th:text="${post.dueDate}">2025-07-01</td>
-      <td th:text="${post.isTarget ? '✔️' : '❌'}"></td>
-      <td class="actions">
-        <button onclick="setAsTarget([[${post.id}]])">목표 설정</button>
-        <button class="delete" onclick="deletePost([[${post.id}]])">삭제</button>
-      </td>
-    </tr>
-    </tbody>
-  </table>
 </main>
 
-<!-- ✅ 알림/채팅 -->
-<div th:replace="fragments/chatbot/chatbot :: chatbot"></div>
-
-<!-- ✅ JS -->
 <script>
-  function openJobPostingModal() {
-    document.getElementById("jobPostingModal").style.display = "block";
-  }
+  document.addEventListener('DOMContentLoaded', function () {
+    let targetCompanies = [];
 
-  function closeJobPostingModal() {
-    document.getElementById("jobPostingModal").style.display = "none";
-  }
+    loadTargetCompanies();
+    updateDDayNotification();
 
-  let currentDeleteId = null;
+    document.getElementById('addCompanyForm').addEventListener('submit', function (e) {
+      e.preventDefault();
+      const companyName = document.getElementById('companyName').value;
+      const deadline = document.getElementById('deadline').value;
 
-  function deletePost(id) {
-    currentDeleteId = id;
-    document.getElementById("jobDeleteModal").style.display = "block";
-  }
-
-  function closeJobDeleteModal() {
-    currentDeleteId = null;
-    document.getElementById("jobDeleteModal").style.display = "none";
-  }
-
-  document.addEventListener("DOMContentLoaded", function () {
-    document.getElementById("confirmJobDeleteBtn").addEventListener("click", function () {
-      if (currentDeleteId !== null) {
-        fetch(`/jobposting/${currentDeleteId}`, { method: 'DELETE' })
-        .then(() => location.reload())
-        .catch(e => alert('❌ 삭제 실패'));
+      if (!companyName || !deadline) {
+        alert('기업명과 마감일을 모두 입력해주세요.');
+        return;
       }
-    });
-  });
 
-  function setAsTarget(id) {
-    fetch(`/jobposting/target/${id}`, { method: 'POST' })
-    .then(() => location.reload())
-    .catch(e => alert('❌ 목표 설정 실패'));
-  }
+      addTargetCompany(companyName, deadline);
+    });
+
+    function addTargetCompany(companyName, deadline) {
+      const requestData = {
+        companyName: companyName,
+        dueDate: deadline
+      };
+
+      // ✅ CSRF 토큰 처리
+      const csrfToken = document.querySelector('meta[name="_csrf"]').getAttribute('content');
+      const csrfHeader = document.querySelector('meta[name="_csrf_header"]').getAttribute('content');
+
+      fetch('/jobposting', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          [csrfHeader]: csrfToken
+        },
+        body: JSON.stringify(requestData)
+      })
+      .then(response => {
+        if (response.ok) {
+          document.getElementById('addCompanyForm').reset();
+          loadTargetCompanies();
+          alert('목표기업이 추가되었습니다!');
+        } else {
+          throw new Error('목표기업 추가 실패');
+        }
+      })
+      .catch(error => {
+        console.error('목표기업 추가 실패:', error);
+        alert('목표기업 추가에 실패했습니다.');
+      });
+    }
+
+    function loadTargetCompanies() {
+      fetch('/jobposting')
+      .then(res => res.json())
+      .then(data => {
+        targetCompanies = data;
+        renderCompanyList();
+        updateDDayNotification();
+      })
+      .catch(err => {
+        console.error('목표기업 목록 불러오기 실패:', err);
+        renderEmptyState();
+      });
+    }
+
+    function renderCompanyList() {
+      const container = document.getElementById('companyList');
+      if (targetCompanies.length === 0) {
+        renderEmptyState();
+        return;
+      }
+
+      container.innerHTML = targetCompanies.map(company => {
+        const dday = calculateDDay(company.dueDate);
+        const ddayClass = getDDayClass(company.dueDate);
+        return `
+          <div class="company-item">
+            <div class="company-info">
+              <div class="company-icon">🏢</div>
+              <div class="company-details">
+                <div class="company-name">${company.title || company.companyName}</div>
+                <div class="company-deadline">마감일: ${company.dueDate}</div>
+              </div>
+            </div>
+            <div class="dday-badge ${ddayClass}">${dday}</div>
+            <button class="delete-btn" onclick="deleteTargetCompany(${company.id})">🗑️ 삭제</button>
+          </div>`;
+      }).join('');
+    }
+
+    function deleteTargetCompany(id) {
+      const csrfToken = document.querySelector('meta[name="_csrf"]').getAttribute('content');
+      const csrfHeader = document.querySelector('meta[name="_csrf_header"]').getAttribute('content');
+
+      fetch(`/jobposting/${id}`, {
+        method: 'DELETE',
+        headers: {
+          [csrfHeader]: csrfToken
+        }
+      })
+      .then(response => {
+        if (response.ok) {
+          loadTargetCompanies();
+          alert('목표기업이 삭제되었습니다.');
+        } else {
+          throw new Error('삭제 실패');
+        }
+      })
+      .catch(err => {
+        console.error('삭제 실패:', err);
+        alert('삭제에 실패했습니다.');
+      });
+    }
+
+    function calculateDDay(deadline) {
+      const today = new Date();
+      const dueDate = new Date(deadline);
+      const diff = dueDate - today;
+      const days = Math.ceil(diff / (1000 * 60 * 60 * 24));
+      return days < 0 ? `D+${-days}` : (days === 0 ? 'D-Day' : `D-${days}`);
+    }
+
+    function getDDayClass(deadline) {
+      const today = new Date();
+      const due = new Date(deadline);
+      const diffDays = Math.ceil((due - today) / (1000 * 60 * 60 * 24));
+      return diffDays <= 0 ? 'dday-urgent' : diffDays <= 7 ? 'dday-warning' : 'dday-normal';
+    }
+
+    function renderEmptyState() {
+      document.getElementById('companyList').innerHTML = `
+        <div class="empty-state">
+          <div class="empty-icon">📋</div>
+          <p>아직 등록된 목표기업이 없습니다.</p>
+          <p>위 폼을 통해 목표기업을 추가해보세요!</p>
+        </div>`;
+    }
+
+    function updateDDayNotification() {
+      const notification = document.getElementById('ddayNotification');
+      const ddayText = document.getElementById('ddayText');
+      const mainContent = document.getElementById('mainContent');
+
+      if (targetCompanies.length === 0) {
+        notification.classList.remove('show');
+        mainContent.classList.remove('with-dday');
+        return;
+      }
+
+      const urgent = targetCompanies.reduce((a, b) => new Date(a.dueDate) < new Date(b.dueDate) ? a : b);
+      const dday = calculateDDay(urgent.dueDate);
+      const diffDays = Math.ceil((new Date(urgent.dueDate) - new Date()) / (1000 * 60 * 60 * 24));
+
+      if (diffDays <= 7) {
+        ddayText.innerHTML = `<span class="dday-urgent">🚨 ${urgent.companyName} ${dday}</span> <span>마감일이 얼마 남지 않았습니다!</span>`;
+        notification.classList.add('show');
+        mainContent.classList.add('with-dday');
+      } else {
+        notification.classList.remove('show');
+        mainContent.classList.remove('with-dday');
+      }
+    }
+
+    // 전역 등록
+    window.deleteTargetCompany = deleteTargetCompany;
+  });
 </script>
+
+<th:block th:replace="fragments/common/chatbot-modal :: chatbot"></th:block>
 </body>
 </html>

--- a/src/main/resources/templates/todo/calender.html
+++ b/src/main/resources/templates/todo/calender.html
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>캘린더 - 날짜 선택</title>
 
-  <!-- ✅ 헤더 스타일 -->
-  <link rel="stylesheet" th:href="@{/css/fragment/header.css}" />
-  <link rel="stylesheet" th:href="@{/css/fragment/sidenav.css}" />
+  <!-- ✅ 공통 스타일 -->
+  <link rel="stylesheet" th:href="@{/css/fragment/header.css}"/>
+  <link rel="stylesheet" th:href="@{/css/fragment/sidenav.css}"/>
+  <link rel="stylesheet" th:href="@{/css/fragment/chatbot.css}"/>
 
   <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.css" rel="stylesheet" />
   <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
@@ -41,14 +42,11 @@
     }
 
     main {
-      position: absolute;
-      top: 100px;
-      left: 270px;
-      width: calc(100vw - 270px);
-      min-height: calc(100vh - 116px);
-      padding: 40px;
-      display: block;
-      background-color: #F8F9FA;
+      margin-left: 280px;
+      margin-top: 100px;
+      padding: 30px;
+      min-height: calc(100vh - 100px);
+      background-color: #f8f9fa;
     }
 
     .calendar-wrapper {

--- a/src/main/resources/templates/todo/todo-list.html
+++ b/src/main/resources/templates/todo/todo-list.html
@@ -5,8 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>투두 리스트 조회</title>
 
-  <link rel="stylesheet" th:href="@{/css/fragment/header.css}" />
-  <link rel="stylesheet" th:href="@{/css/fragment/sidenav.css}" />
+  <!-- ✅ 공통 스타일 -->
+  <link rel="stylesheet" th:href="@{/css/fragment/header.css}"/>
+  <link rel="stylesheet" th:href="@{/css/fragment/sidenav.css}"/>
+  <link rel="stylesheet" th:href="@{/css/fragment/chatbot.css}"/>
 
   <style>
     body {
@@ -34,12 +36,10 @@
     }
 
     main {
-      position: absolute;
-      top: 100px;
-      left: 270px;
-      width: calc(100vw - 270px);
-      min-height: calc(100vh - 116px);
-      padding: 40px;
+      margin-left: 280px;
+      margin-top: 100px;
+      padding: 30px;
+      min-height: calc(100vh - 100px);
       background-color: #f8f9fa;
     }
 


### PR DESCRIPTION
📌 과제 설명
채용공고 & 목표기업 관리 페이지를 구현했습니다. 사용자가 목표기업을 등록하고 마감일 기준으로 D-Day를 계산하여 확인할 수 있도록 구성했습니다.

헤더쪽 알림 메시지 이슈는 추후에 개선할 계획입니다. 

👩‍💻 요구 사항과 구현 내용
채용 사이트 카드 UI 구현 (원티드, 사람인 등 6개 사이트 링크 포함)

목표기업 등록 폼 구현 (기업명, 마감일 입력 후 추가)

등록된 목표기업 목록 표시 및 삭제 기능 구현

각 기업의 마감일을 기준으로 D-Day 계산 및 시각적 구분 처리 (급함, 주의, 여유)

마감일이 가까운 기업은 D-Day 알림 바로 강조 표시
